### PR TITLE
Improve sidebar usability

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
             top: 0;
             left: 0;
             right: 0;
-            z-index: 1000; /* Increased z-index */
+            z-index: 1050; /* Sit above the overlay */
             padding: 1rem 1rem; /* p-4 */
             display: flex;
             align-items: center;
@@ -1173,12 +1173,12 @@
 <body>
     <header>
         <div id="header-main">
-            <button id="sidebar-toggle-button" title="Toggle Navigation Menu">
+            <button id="sidebar-toggle-button" title="Toggle Navigation Menu" aria-controls="main-nav" aria-expanded="false">
                 <i class="fas fa-bars"></i>
             </button>
             <h1 class="logo"><img src="Sad Face.png" alt="Sad Face Logo" style="height: 1.5em; vertical-align: middle;"></h1>
             <span id="current-tab-name-display">Watch TV+</span> </div>
-        <nav id="main-nav"> <a href="#" class="tab-link active-nav-link" data-tab="watch-now-tab">Watch TV+</a>
+        <nav id="main-nav" aria-hidden="true"> <a href="#" class="tab-link active-nav-link" data-tab="watch-now-tab">Watch TV+</a>
             <a href="#" class="tab-link" data-tab="explore-tab">Explore</a>
             <a href="#" class="tab-link" data-tab="library-tab">Library</a>
             <a href="#" class="tab-link" data-tab="seen-tab">Seen</a>

--- a/main.js
+++ b/main.js
@@ -247,6 +247,7 @@ window.onload = async () => {
         mainNav?.classList.remove('sidebar-open');
         secondarySidebar?.classList.remove('open');
         sidebarOverlay?.classList.remove('active');
+        document.body.style.overflow = '';
         if (mainNav?.classList.contains('sidebar-open') === false) updateSidebarButtonState(false);
         console.log(`[DEBUG] switchTab for ${tabId} finished.`);
     }
@@ -446,6 +447,9 @@ window.onload = async () => {
     function updateSidebarButtonState(isOpen) {
         if (sidebarToggleButton && sidebarToggleIcon) {
             sidebarToggleButton.setAttribute('aria-expanded', isOpen);
+            if (mainNav) {
+                mainNav.setAttribute('aria-hidden', (!isOpen).toString());
+            }
             if (isOpen) {
                 sidebarToggleIcon.classList.remove('fa-bars');
                 sidebarToggleIcon.classList.add('fa-times');
@@ -462,6 +466,7 @@ window.onload = async () => {
     sidebarToggleButton?.addEventListener('click', () => {
         const isOpen = mainNav?.classList.toggle('sidebar-open');
         sidebarOverlay?.classList.toggle('active', isOpen);
+        document.body.style.overflow = isOpen ? 'hidden' : '';
         updateSidebarButtonState(isOpen);
     });
 
@@ -497,6 +502,7 @@ window.onload = async () => {
     sidebarOverlay?.addEventListener('click', () => {
         if (mainNav?.classList.contains('sidebar-open')) {
             mainNav.classList.remove('sidebar-open');
+            document.body.style.overflow = '';
             updateSidebarButtonState(false);
         }
         if (secondarySidebar && secondarySidebar.classList.contains('open')) {
@@ -506,6 +512,17 @@ window.onload = async () => {
             closeFilterModal();
         }
         sidebarOverlay?.classList.remove('active');
+    });
+
+    // Close sidebar with Escape key
+    document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape' && mainNav?.classList.contains('sidebar-open')) {
+            mainNav.classList.remove('sidebar-open');
+            sidebarOverlay?.classList.remove('active');
+            document.body.style.overflow = '';
+            updateSidebarButtonState(false);
+            sidebarToggleButton?.focus();
+        }
     });
 
     // Sidebar Navigation tab clicks


### PR DESCRIPTION
## Summary
- bump header `z-index` so sidebar overlay doesn't block clicks
- render sidebar and toggle button with accessible ARIA attributes
- close sidebar on escape key and disable body scroll while open

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684928fcfec883239e3f30dc2d1aa9f2