### PR TITLE
Improve modal CSS responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -300,8 +300,8 @@
         .hero-section img {
             position: absolute;
             inset: 0;
-            width: 100%;
-            height: 100%;
+            width: 100vw;
+            height: 100vh;
             object-fit: cover;
             opacity: 0.7;
         }
@@ -363,8 +363,8 @@
             position: fixed;
             top: 0;
             left: 0;
-            width: 100%;
-            height: 100%;
+            width: 100vw;
+            height: 100vh;
             background-color: rgba(0, 0, 0, 0.8);
             z-index: 1000;
             justify-content: center;
@@ -378,7 +378,8 @@
             background-color: var(--bg-primary);
             border-radius: 0.75rem;
             padding: 2rem;
-            max-width: 900px;
+            max-width: 100vw;
+            max-height: 100vh;
             width: 95%;
             box-shadow: 0 0 20px rgba(0, 0, 0, 0.5);
             position: relative;
@@ -386,6 +387,7 @@
             opacity: 0;
             animation: fadeInModal 0.3s forwards;
             color: var(--text-primary);
+            box-sizing: border-box;
         }
 
         @keyframes fadeInModal {
@@ -1167,6 +1169,17 @@
         @media (max-width: 600px) {
             header .icon-buttons { /* This is the original container for theme, filter, etc. */
                 display: none;
+            }
+        }
+
+        @media screen and (max-width: 600px) {
+            .item-detail-modal-content {
+                width: 100%;
+                height: 100%;
+                max-width: none;
+                max-height: none;
+                border-radius: 0;
+                padding: 1rem;
             }
         }
     </style>


### PR DESCRIPTION
## Summary
- adjust item-detail-modal to use viewport width and height
- limit item-detail-modal-content using box-sizing and viewport-sized defaults
- add mobile rule for full-screen modal content

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_6849352276c08323a61b2b2cd07a17b8