### PR TITLE
Add Firebase config setup

### DIFF
--- a/firebase-config.js
+++ b/firebase-config.js
@@ -1,0 +1,14 @@
+// Example Firebase configuration. Replace these values with your Firebase project's details.
+window.firebaseConfig = {
+    apiKey: "YOUR_API_KEY",
+    authDomain: "your-project.firebaseapp.com",
+    projectId: "your-project-id",
+    storageBucket: "your-project.appspot.com",
+    messagingSenderId: "YOUR_SENDER_ID",
+    appId: "YOUR_APP_ID"
+};
+
+// Optional: provide the Canvas-style __firebase_config string if not already defined.
+if (typeof window.__firebase_config === 'undefined') {
+    window.__firebase_config = JSON.stringify(window.firebaseConfig);
+}

--- a/index.html
+++ b/index.html
@@ -1374,6 +1374,7 @@
     </div>
 
 
+    <script src="firebase-config.js"></script>
     <script src="config.js" type="module"></script>
     <script src="api.js" type="module"></script>
     <script src="ui.js" type="module"></script>

--- a/main.js
+++ b/main.js
@@ -66,13 +66,24 @@ window.onload = async () => {
     }, 100); // Check every 100ms
 
     async function initializeAndAuthFirebase() {
-        // Now it's guaranteed that window.__firebase_config is defined
-        const firebaseConfig = JSON.parse(window.__firebase_config);
+        let firebaseConfig;
+        if (typeof window.__firebase_config !== 'undefined') {
+            try {
+                firebaseConfig = JSON.parse(window.__firebase_config);
+            } catch (e) {
+                console.error('Failed to parse __firebase_config', e);
+            }
+        }
+
+        if (!firebaseConfig && typeof window.firebaseConfig !== 'undefined') {
+            firebaseConfig = window.firebaseConfig;
+        }
+
         const initialAuthToken = window.__initial_auth_token;
 
         if (!firebaseConfig) {
-            console.error("Firebase configuration (__firebase_config) is not available. Firebase features will be disabled.");
-            showCustomAlert('Error', 'Firebase configuration missing. Core features may not work.', 'error');
+            console.error('Firebase configuration is not available.');
+            showCustomAlert('Error', 'Firebase must be configured before using this application. Please update firebase-config.js with your project details.', 'error');
             return;
         }
 


### PR DESCRIPTION
## Summary
- add example `firebase-config.js` that defines `window.firebaseConfig`
- load that script in `index.html` before other modules
- initialize Firebase using `window.__firebase_config` or fallback to `window.firebaseConfig`
- show a helpful error when Firebase isn't configured

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849373840c08323ba8213be4b614a19