### PR TITLE
Update auth form fields to include autocomplete

### DIFF
--- a/SignIn/auth.js
+++ b/SignIn/auth.js
@@ -74,6 +74,7 @@ export function createAuthFormUI(parentElement, onSuccessCallback) {
     emailField.placeholder = 'Email';
     emailField.className = 'auth-dropdown-input w-full mb-2';
     emailField.name = 'email'; // Good practice for forms
+    emailField.autocomplete = 'email';
     form.appendChild(emailField);
 
     const passwordField = document.createElement('input');
@@ -81,6 +82,7 @@ export function createAuthFormUI(parentElement, onSuccessCallback) {
     passwordField.placeholder = 'Password';
     passwordField.className = 'auth-dropdown-input w-full mb-3';
     passwordField.name = 'password'; // Good practice for forms
+    passwordField.autocomplete = 'current-password';
     form.appendChild(passwordField);
 
     const buttonContainer = document.createElement('div');


### PR DESCRIPTION
## Summary
- ensure SignIn form sets HTML `autocomplete` attributes for email and password fields

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684a9aa83fac8323bcd4f40d02715d4b