### PR TITLE
Update app ID fallback in firebase_api

### DIFF
--- a/SignIn/firebase_api.js
+++ b/SignIn/firebase_api.js
@@ -4,7 +4,11 @@ import { getFirebaseAuth, getFirebaseFirestore, firebaseAuthFunctions, firebaseF
 import { showCustomAlert } from '../ui.js';
 
 // Define appId globally using the __app_id provided by the Canvas environment
-const appId = typeof __app_id !== 'undefined' ? __app_id : 'default-app-id';
+// or fall back to window.firebaseConfig.projectId if available.
+const appId =
+    (typeof __app_id !== 'undefined' && __app_id) ||
+    (window.firebaseConfig && window.firebaseConfig.projectId) ||
+    'default-app-id';
 
 /**
  * Helper to get the authenticated user.


### PR DESCRIPTION
## Summary
- ensure `appId` falls back to `window.firebaseConfig.projectId` before using default

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684a9cd8a3b48323b502ca9c111db0ad