### PR TITLE
Update Firebase CDN links

### DIFF
--- a/SignIn/firebase.js
+++ b/SignIn/firebase.js
@@ -1,9 +1,9 @@
 // SignIn/firebase.js
 // Updated Firebase SDK imports to use CDN paths for browser compatibility
-import { initializeApp, getApps, getApp } from 'https://www.gstatic.com/firebasejs/10.0.0/firebase-app.js';
-import { getAnalytics } from 'https://www.gstatic.com/firebasejs/10.0.0/firebase-analytics.js';
-import * as FirebaseAuthFunctions from 'https://www.gstatic.com/firebasejs/10.0.0/firebase-auth.js';
-import * as FirebaseFirestoreFunctions from 'https://www.gstatic.com/firebasejs/10.0.0/firebase-firestore.js';
+import { initializeApp, getApps, getApp } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-app.js';
+import { getAnalytics } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-analytics.js';
+import * as FirebaseAuthFunctions from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-auth.js';
+import * as FirebaseFirestoreFunctions from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-firestore.js';
 
 let appInstance = null;
 let analyticsInstance = null;


### PR DESCRIPTION
## Summary
- bump Firebase CDN import version from `10.0.0` to `11.9.1`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684aa51d85dc8323812e0074c3bcd222