### PR TITLE
Improve watchlist selection UX

### DIFF
--- a/modules/libraryManager.js
+++ b/modules/libraryManager.js
@@ -1,7 +1,7 @@
 // modules/libraryManager.js
 
 import { getCurrentUser, saveUserData, deleteUserData, listenToUserCollection } from '../SignIn/firebase_api.js';
-import { showCustomAlert, showLoadingIndicator, hideLoadingIndicator } from '../ui.js';
+import { showCustomAlert, showLoadingIndicator, hideLoadingIndicator, showToast } from '../ui.js';
 import { createContentCardHtml } from '../ui.js'; // Import directly from ui.js
 
 // Local cache for user's watchlists
@@ -141,7 +141,6 @@ export async function addRemoveItemToFolder(folderId, itemDetails, itemType) {
     }
 
     try {
-        showLoadingIndicator('Updating watchlist...');
 
         // Find the target watchlist in the current cache
         const targetWatchlist = firestoreWatchlistsCache.find(wl => wl.id === folderId);
@@ -162,10 +161,10 @@ export async function addRemoveItemToFolder(folderId, itemDetails, itemType) {
 
         if (existingIndex > -1) {
             itemsArray.splice(existingIndex, 1);
-            showCustomAlert('Success', `Removed "${normalizedItem.title}" from "${targetWatchlist.name}".`);
+            showToast(`Removed "${normalizedItem.title}" from "${targetWatchlist.name}"`);
         } else {
             itemsArray.push(normalizedItem);
-            showCustomAlert('Success', `Added "${normalizedItem.title}" to "${targetWatchlist.name}".`);
+            showToast(`Added "${normalizedItem.title}" to "${targetWatchlist.name}"`);
         }
 
         // Update the local cache immediately so UI reflects the change
@@ -182,8 +181,6 @@ export async function addRemoveItemToFolder(folderId, itemDetails, itemType) {
     } catch (error) {
         console.error('Error updating watchlist folder:', error);
         showCustomAlert('Error', `Failed to update watchlist: ${error.message}`);
-    } finally {
-        hideLoadingIndicator();
     }
 }
 

--- a/ui.js
+++ b/ui.js
@@ -558,3 +558,32 @@ export function updateThemeDependentElements(isLightMode) {
         }
     });
 }
+
+// --- Toast Notification ---
+const toastContainer = document.createElement('div');
+toastContainer.id = 'toast-container';
+toastContainer.style.position = 'fixed';
+toastContainer.style.bottom = '20px';
+toastContainer.style.left = '50%';
+toastContainer.style.transform = 'translateX(-50%)';
+toastContainer.style.zIndex = '1000';
+document.body.appendChild(toastContainer);
+
+/**
+ * Shows a temporary toast notification.
+ * @param {string} message - Message to display.
+ * @param {number} [duration=2000] - Duration in ms.
+ */
+export function showToast(message, duration = 2000) {
+    const toast = document.createElement('div');
+    toast.textContent = message;
+    toast.style.background = 'rgba(0, 0, 0, 0.85)';
+    toast.style.color = '#fff';
+    toast.style.padding = '0.5rem 1rem';
+    toast.style.marginTop = '0.5rem';
+    toast.style.borderRadius = '4px';
+    toast.style.fontSize = '0.9rem';
+    toast.style.boxShadow = '0 2px 6px rgba(0,0,0,0.3)';
+    toastContainer.appendChild(toast);
+    setTimeout(() => toast.remove(), duration);
+}


### PR DESCRIPTION
## Summary
- add toast notification system
- use toast instead of blocking alerts when adding/removing items

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684b42ca186c83238fe84204c0e10a8e