### PR TITLE
Add gradient overlay hero style

### DIFF
--- a/index.html
+++ b/index.html
@@ -307,27 +307,35 @@
             height: 20rem; /* h-80 */
             border-radius: 0.5rem; /* rounded-lg */
             overflow: hidden;
+            box-shadow: 0 0 20px rgba(0,0,0,0.4);
             display: flex;
             align-items: flex-end; /* items-end */
-            padding: 1.5rem; /* p-6 */
             margin-bottom: 3rem; /* mb-12 */
-            box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05); /* shadow-xl */
-            background: linear-gradient(to bottom right, var(--gradient-start), var(--gradient-end)); /* dynamic gradient */
+            color: var(--text-primary);
+            font-family: 'Inter', sans-serif;
         }
 
-        .hero-section img {
+        .hero-section .background-image {
+            background-size: cover;
+            background-position: center;
             position: absolute;
-            inset: 0;
-            width: 100vw;
-            height: 100vh;
-            object-fit: cover;
-            opacity: 0.7;
+            width: 100%;
+            height: 100%;
+            z-index: 1;
+        }
+
+        .hero-section .gradient-overlay {
+            position: absolute;
+            width: 100%;
+            height: 100%;
+            background: linear-gradient(to right, rgba(0,0,0,0.9) 30%, transparent 100%);
+            z-index: 2;
         }
 
         .hero-section .content {
             position: relative;
-            z-index: 10;
-            color: var(--text-primary);
+            z-index: 3;
+            padding: 1.5rem; /* p-6 */
             max-width: 32rem; /* max-w-lg */
         }
         /* Span to display current tab name */
@@ -1317,8 +1325,8 @@
     <div id="sidebar-overlay"></div> <main id="main-content">
         <section class="tab-content active-tab" id="watch-now-tab">
             <section class="hero-section">
-                <img id="hero-image-element" src="" alt="Featured Show"
-                    onerror="this.onerror=null;this.src='https://placehold.co/1200x600/3B0764/F3F4F6?text=Fallback+Image';">
+                <div class="background-image" id="hero-image-element"></div>
+                <div class="gradient-overlay"></div>
                 <div class="content">
                     <h2 id="hero-title">Featured Content</h2>
                     <p id="hero-overview">Discover the latest blockbusters and critically acclaimed series.</p>

--- a/ui.js
+++ b/ui.js
@@ -540,7 +540,9 @@ export function renderWatchlistOptionsInModal(currentItemDetails, watchlistsCach
 export function updateHeroSection(imageUrl, title, description) {
     const heroImage = document.getElementById('hero-image-element');
     const heroContent = document.querySelector('.hero-section .content');
-    heroImage.src = (typeof imageUrl === 'string') ? imageUrl : '';
+    if (heroImage) {
+        heroImage.style.backgroundImage = imageUrl ? `url('${imageUrl}')` : '';
+    }
     if (heroContent) {
         heroContent.innerHTML = `
             <h2>${title || ''}</h2>


### PR DESCRIPTION
## Summary
- restyle hero section to use a full size background image with gradient overlay
- adjust markup to use background div and overlay layer
- update `updateHeroSection` to apply background image style

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b777937788323b65a673ba2707827