### PR TITLE
Display IMDb logo instead of text links

### DIFF
--- a/modules/netflixModal.js
+++ b/modules/netflixModal.js
@@ -72,7 +72,7 @@ export function openNetflixModal({ imageSrc = '', title = '', tags = [], descrip
 
   if (imdbUrl) {
     const imdbP = document.createElement('p');
-    imdbP.innerHTML = `<strong>IMDb:</strong> <a href="${imdbUrl}" target="_blank">View on IMDb</a>`;
+    imdbP.innerHTML = `<strong>IMDb:</strong> <a href="${imdbUrl}" target="_blank"><img src="IMDb.png" alt="IMDb" style="height: 1.2em; vertical-align: middle;"></a>`;
     infoDiv.appendChild(imdbP);
   }
 

--- a/ui.js
+++ b/ui.js
@@ -326,7 +326,7 @@ export function displayItemDetails(detailsObject, itemType, isLightMode) {
     const imdbId = detailsObject.external_ids && detailsObject.external_ids.imdb_id;
     let imdbLinkHtmlSegment;
     if (imdbId) {
-        imdbLinkHtmlSegment = `<a href="https://www.imdb.com/title/${imdbId}/" target="_blank" style="color: var(--science-blue); text-decoration: none;">View on IMDb</a>`;
+        imdbLinkHtmlSegment = `<a href="https://www.imdb.com/title/${imdbId}/" target="_blank"><img src="IMDb.png" alt="IMDb" style="height: 1.2em; vertical-align: middle;"></a>`;
     } else {
         imdbLinkHtmlSegment = `Not Available`;
     }


### PR DESCRIPTION
## Summary
- show IMDb logo in content cards instead of text link
- use the same logo in Netflix-style modal

## Testing
- `npm ls` *(fails: missing packages)*
- `npm install` *(fails: integrity checksum error)*

------
https://chatgpt.com/codex/tasks/task_e_684b9298580083238ac0f8a151035655