### PR TITLE
Improve IMDb button appearance and placement

### DIFF
--- a/index.html
+++ b/index.html
@@ -526,11 +526,12 @@
             display: inline-flex;
             align-items: center;
             background-color: #333;
-            padding: 0.25rem 0.5rem;
-            border-radius: 9999px;
+            padding: 0;
+            border-radius: 0.25rem;
         }
         .movie-modal-tags a.imdb-link img {
-            height: 0.75rem;
+            height: 1rem;
+            display: block;
         }
         .movie-modal-description {
             color: var(--text-secondary);
@@ -616,11 +617,12 @@
             display: inline-flex;
             align-items: center;
             background-color: rgba(255,255,255,0.2);
-            padding: 0.25rem 0.5rem;
+            padding: 0;
             border-radius: 0.25rem;
         }
         .netflix-modal-tags a.imdb-link img {
-            height: 0.75rem;
+            height: 1rem;
+            display: block;
         }
         .netflix-modal-body {
             padding: 1rem 1.5rem 1.5rem 1.5rem;

--- a/modules/netflixModal.js
+++ b/modules/netflixModal.js
@@ -33,17 +33,25 @@ export function openNetflixModal({ imageSrc = '', title = '', tags = [], descrip
 
   const tagsDiv = document.createElement('div');
   tagsDiv.className = 'netflix-modal-tags';
-  tags.forEach(tag => {
-    const span = document.createElement('span');
-    span.textContent = tag;
-    tagsDiv.appendChild(span);
-  });
+  let imdbInserted = false;
+  let imdbLink;
   if (imdbUrl) {
-    const imdbLink = document.createElement('a');
+    imdbLink = document.createElement('a');
     imdbLink.href = imdbUrl;
     imdbLink.target = '_blank';
     imdbLink.className = 'imdb-link';
     imdbLink.innerHTML = `<img src="IMDb.png" alt="IMDb">`;
+  }
+  tags.forEach(tag => {
+    const span = document.createElement('span');
+    span.textContent = tag;
+    tagsDiv.appendChild(span);
+    if (!imdbInserted && imdbLink && (tag === 'Movie' || tag === 'TV')) {
+      tagsDiv.appendChild(imdbLink);
+      imdbInserted = true;
+    }
+  });
+  if (imdbLink && !imdbInserted) {
     tagsDiv.appendChild(imdbLink);
   }
   infoOverlay.appendChild(tagsDiv);

--- a/ui.js
+++ b/ui.js
@@ -362,8 +362,8 @@ export function displayItemDetails(detailsObject, itemType, isLightMode) {
             <span>${yearTag}</span>
             <span>${certificationTag}</span>
             <span>${typeTag}</span>
-            ${genresTags}
             ${imdbLogoHtml}
+            ${genresTags}
         </div>
         <p class="movie-modal-description">${overview}</p>
         <div class="movie-modal-actions">${actionsRowHtml}</div>


### PR DESCRIPTION
## Summary
- update modal styles so the IMDb logo fills its tag button and enlarge it
- move IMDb logo next to the `Movie`/`TV` tag in item detail modal
- insert IMDb logo near the `Movie` category in Netflix-style modal

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684b9930ea848323a15d4929d955daf6