### PR TITLE
Enable interactivity for Netflix modal buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,8 @@ openNetflixModal({
 });
 ```
 
+Inside the modal you can mark the item as seen using the checkmark button, save
+it to your watchlist with the bookmark icon, or launch the first available
+streaming link by clicking **Watch Now**.
+
 The rest of the project uses plain JavaScript modules, so no React setup is required.

--- a/index.html
+++ b/index.html
@@ -667,6 +667,10 @@
         .netflix-modal-action-btn:hover {
             opacity: 0.9;
         }
+        .netflix-modal-action-btn.active {
+            background-color: #2563eb;
+            color: #fff;
+        }
         .watch-now-wrapper {
             display: flex;
             justify-content: center;

--- a/modules/netflixModal.js
+++ b/modules/netflixModal.js
@@ -93,6 +93,30 @@ export function openNetflixModal({ imageSrc = '', title = '', tags = [], descrip
   watchNowBtn.className = 'watch-now-btn';
   watchNowBtn.innerHTML = '<i class="fas fa-play"></i> Watch Now';
 
+  // --- Button functionality ---
+  let isSeen = false;
+  let isBookmarked = false;
+
+  seenBtn.addEventListener('click', () => {
+    isSeen = !isSeen;
+    seenBtn.classList.toggle('active', isSeen);
+    seenBtn.title = isSeen ? 'Marked as Seen' : 'Mark as Seen';
+  });
+
+  watchlistBtn.addEventListener('click', () => {
+    isBookmarked = !isBookmarked;
+    watchlistBtn.classList.toggle('active', isBookmarked);
+    watchlistBtn.title = isBookmarked ? 'Remove Bookmark' : 'Add to Watchlist';
+  });
+
+  watchNowBtn.addEventListener('click', () => {
+    if (streamingLinks && streamingLinks.length > 0) {
+      window.open(streamingLinks[0].url, '_blank');
+    } else if (imdbUrl) {
+      window.open(imdbUrl, '_blank');
+    }
+  });
+
   watchNowWrapper.appendChild(watchNowBtn);
   body.appendChild(watchNowWrapper);
 


### PR DESCRIPTION
## Summary
- update README with instructions about modal button actions
- style active state for modal action buttons
- add button handlers for checkmark, bookmark and Watch Now in `openNetflixModal`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_684b9d9a3ef48323a1934caa58aaba9f