### PR TITLE
Refine modal watch now button

### DIFF
--- a/index.html
+++ b/index.html
@@ -673,19 +673,18 @@
         }
         .watch-now-wrapper {
             display: flex;
-            justify-content: center;
-            width: 100%;
-            margin-top: 1rem;
+            align-items: center;
+            gap: 0.5rem;
         }
         .watch-now-btn {
             display: flex;
             align-items: center;
             gap: 0.5rem;
-            background-color: var(--black);
+            background-color: var(--science-blue);
             color: var(--white);
             border: none;
             padding: 0.75rem 1.5rem;
-            border-radius: 0.25rem;
+            border-radius: 9999px; /* rounded-full */
             font-weight: 600;
             cursor: pointer;
             width: auto;
@@ -693,7 +692,7 @@
             transition: background-color 0.3s ease-in-out;
         }
         .watch-now-btn:hover {
-            background-color: #222;
+            opacity: 0.9;
         }
         .watch-now-btn i {
             margin-right: 0.25rem;

--- a/modules/netflixModal.js
+++ b/modules/netflixModal.js
@@ -94,9 +94,7 @@ export function openNetflixModal({ itemDetails = null, imageSrc = '', title = ''
     </div>`;
   actions.appendChild(watchlistDropdown);
 
-  body.appendChild(actions);
-
-  // "Watch Now" button centered within the modal
+  // "Watch Now" button displayed with other action icons
   const watchNowWrapper = document.createElement('div');
   watchNowWrapper.className = 'watch-now-wrapper';
 
@@ -144,7 +142,9 @@ export function openNetflixModal({ itemDetails = null, imageSrc = '', title = ''
   if (streamingLinks && streamingLinks.length > 0) {
     watchNowWrapper.appendChild(watchNowSelect);
   }
-  body.appendChild(watchNowWrapper);
+  actions.appendChild(watchNowWrapper);
+
+  body.appendChild(actions);
 
   const infoDiv = document.createElement('div');
   infoDiv.className = 'netflix-modal-info';


### PR DESCRIPTION
## Summary
- style the **Watch Now** button to use accent color and rounded design
- remove extra margin and align the button beside other modal actions
- update modal script to place the **Watch Now** button next to the checkmark and bookmark actions

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684ba1dd971c83238a99afef313177eb