### PR TITLE
Unify UI action colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
             --shark: #1D1D1F;
             --athens-gray: #F5F5F7;
             --white: #FFFFFF;
+            --accent-color: var(--science-blue);
             --black: #000000;
 
             /* Default (Dark Mode) colors */
@@ -654,22 +655,19 @@
             gap: 0.5rem;
         }
         .netflix-modal-action-btn {
-            background-color: #555;
-            color: #fff;
-            border: none;
+            background-color: transparent;
+            color: var(--accent-color);
+            border: 1px solid var(--accent-color);
             padding: 0.5rem 1rem;
             border-radius: 0.25rem;
             cursor: pointer;
+            transition: background-color 0.3s ease-in-out, color 0.3s ease-in-out;
         }
-        .netflix-modal-action-btn.primary {
-            background-color: #2563eb; /* Tailwind blue-600 */
-        }
-        .netflix-modal-action-btn:hover {
-            opacity: 0.9;
-        }
+        .netflix-modal-action-btn.primary,
+        .netflix-modal-action-btn:hover,
         .netflix-modal-action-btn.active {
-            background-color: #2563eb;
-            color: #fff;
+            background-color: var(--accent-color);
+            color: var(--white);
         }
         .watch-now-wrapper {
             display: flex;
@@ -827,7 +825,7 @@
             width: 28px;
             height: 28px;
             background-color: var(--card-bg); /* Matches page background initially */
-            border: 2px solid var(--white);    /* White circle border */
+            border: 2px solid var(--accent-color);
             border-radius: 50%;
             display: flex;
             align-items: center;
@@ -837,12 +835,15 @@
             transition: background-color 0.2s ease-in-out, border-color 0.2s ease-in-out;
         }
         .seen-toggle-icon i { /* Font Awesome check icon */
-            color: var(--white);
+            color: var(--accent-color);
             font-size: 14px;
         }
         .seen-toggle-icon.item-is-seen {
-            background-color: #28a745; /* Green background when seen */
-            border-color: #28a745; /* Green border to match */
+            background-color: var(--accent-color);
+            border-color: var(--accent-color);
+        }
+        .seen-toggle-icon.item-is-seen i {
+            color: var(--white);
         }
 
         .content-card p {
@@ -902,8 +903,8 @@
             display: flex;
             align-items: center;
             justify-content: center;
-            border: 1px solid var(--border-color, #333);
-            color: var(--text-primary, #fff);
+            border: 1px solid var(--accent-color);
+            color: var(--accent-color);
             cursor: pointer;
             transition: border 0.2s;
             box-shadow: 0 1px 3px rgba(60,60,67,0.03);
@@ -937,14 +938,14 @@
             background: var(--dropdown-hover, #2a2a2e);
         }
         .dropdown-list .dropdown-item.selected {
-            color: #0071e3;
+            color: var(--accent-color);
             font-weight: 600;
             background: #1a2636;
         }
         .dropdown-list .dropdown-item .checkmark {
             margin-left: auto;
             font-size: 1.1em;
-            color: #0071e3;
+            color: var(--accent-color);
             opacity: 1;
             transition: opacity 0.2s;
         }
@@ -967,7 +968,7 @@
         }
         .light-mode .dropdown-list .dropdown-item.selected {
             background: #eaf6ff;
-            color: #0071e3;
+            color: var(--accent-color);
         }
         .light-mode .dropdown-list .dropdown-item:hover {
             background: #f0f0f5;
@@ -975,26 +976,26 @@
         /* Styles for selected items in multi-select dropdown */
         .apple-dropdown .dropdown-list .dropdown-item.item-selected {
             background: var(--dropdown-hover, #2a2a2e); /* Use hover color or a specific selected color */
-            color: var(--science-blue); /* Highlight selected text */
+            color: var(--accent-color); /* Highlight selected text */
         }
         .apple-dropdown .dropdown-list .dropdown-item.item-selected .checkmark {
             opacity: 1;
         }
         .light-mode .apple-dropdown .dropdown-list .dropdown-item.item-selected {
             background: #e0e8f0; /* Lighter selected background for light mode */
-            color: var(--science-blue);
+            color: var(--accent-color);
         }
         /* Selected style for filter modal items */
         .dropdown-list .dropdown-item.item-selected {
             background: var(--dropdown-hover, #2a2a2e);
-            color: var(--science-blue);
+            color: var(--accent-color);
         }
         .dropdown-list .dropdown-item.item-selected .checkmark {
             opacity: 1;
         }
         .light-mode .dropdown-list .dropdown-item.item-selected {
             background: #e0e8f0;
-            color: var(--science-blue);
+            color: var(--accent-color);
         }
         /* Style for filter button when a filter is active */
         .icon-buttons #filter-button.filter-active i {


### PR DESCRIPTION
## Summary
- define `--accent-color` and use it across icons
- apply accent color to seen icon and Netflix modal action buttons
- update dropdown colors for bookmarks and selection

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684ba35950ac8323987204ca7463935b