### PR TITLE
Remove unused streaming links section

### DIFF
--- a/index.html
+++ b/index.html
@@ -750,25 +750,6 @@
             color: #1d1d1f;
             border: 1px solid #d1d1d6;
         }
-        .netflix-modal-info p {
-            margin-bottom: 0.5rem;
-            font-size: 0.875rem;
-            line-height: 1.5;
-            color: #ccc;
-        }
-        .netflix-modal-info strong {
-            color: #fff;
-        }
-        .netflix-modal-info .streaming-links a {
-            display: block;
-            margin-bottom: 0.5rem;
-            color: var(--science-blue);
-            text-decoration: none;
-            font-weight: 500;
-        }
-        .netflix-modal-info .streaming-links a:hover {
-            text-decoration: underline;
-        }
         @keyframes netflixFadeIn {
             from { opacity: 0; transform: translateY(20px); }
             to { opacity: 1; transform: translateY(0); }

--- a/modules/netflixModal.js
+++ b/modules/netflixModal.js
@@ -146,32 +146,9 @@ export function openNetflixModal({ itemDetails = null, imageSrc = '', title = ''
 
   body.appendChild(actions);
 
-  const infoDiv = document.createElement('div');
-  infoDiv.className = 'netflix-modal-info';
-
-  // IMDb link now displayed alongside tags
-
-  if (streamingLinks && streamingLinks.length > 0) {
-    const watchOnP = document.createElement('p');
-    watchOnP.style.marginBottom = '0.5rem';
-    watchOnP.innerHTML = '<strong>Watch On:</strong>';
-    infoDiv.appendChild(watchOnP);
-
-    const linksContainer = document.createElement('div');
-    linksContainer.className = 'streaming-links';
-    streamingLinks.forEach(link => {
-      const a = document.createElement('a');
-      a.href = link.url;
-      a.target = '_blank';
-      a.textContent = link.name;
-      linksContainer.appendChild(a);
-    });
-    infoDiv.appendChild(linksContainer);
-  }
-
-  if (infoDiv.children.length > 0) {
-    body.appendChild(infoDiv);
-  }
+  // Optional list of streaming links was previously displayed under the
+  // "Watch Now" button. The dropdown next to the button already provides
+  // provider choices, so this section has been removed.
 
   modal.appendChild(body);
   overlay.appendChild(modal);


### PR DESCRIPTION
## Summary
- remove the `Watch On` links from the Netflix-style modal
- drop related unused CSS

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684ba8750d408323b2791a84e29bca97