### PR TITLE
Add watchlist overlay modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -1726,6 +1726,17 @@
         </div>
     </div>
 
+    <div id="watchlist-modal" class="item-detail-modal">
+        <div class="item-detail-modal-content" style="max-width: 350px; padding: 1.5rem;">
+            <button class="close-button" aria-label="Close"><i class="fas fa-times"></i></button>
+            <h2 style="font-size: 1.5rem; margin-bottom: 1rem; color: var(--text-primary);">Add to Watchlists</h2>
+            <div id="watchlist-options-container" class="dropdown-list hide-scrollbar" style="position: static; max-height: 200px; overflow-y: auto; border: none; box-shadow: none;"></div>
+            <div class="dropdown-footer" style="border-radius: 0.75rem; text-align: center; margin-top: 0.5rem;">
+                <button id="watchlist-add-folder-btn" class="auth-submit-button" style="padding: 0.4em 1em; border-radius: 8px;">+ New Watchlist</button>
+            </div>
+        </div>
+    </div>
+
     <!-- Secondary Sidebar HTML (for mobile "More" options) -->
     <div id="secondary-sidebar" class="secondary-sidebar">
         <button class="close-secondary-sidebar" title="Close"><i class="fas fa-times"></i></button>


### PR DESCRIPTION
## Summary
- add a new watchlist modal overlay in `index.html`
- change the bookmark button in the Netflix-style modal to open the new overlay
- implement `openWatchlistOverlay` for managing watchlist selections

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684bbab4491483238bcead674f7fd5f3