### PR TITLE
Fix watchlist overlay stacking

### DIFF
--- a/index.html
+++ b/index.html
@@ -444,6 +444,11 @@
             box-sizing: border-box;
         }
 
+        /* Ensure watchlist overlay sits above the movie modal */
+        #watchlist-modal {
+            z-index: 1100;
+        }
+
         .item-detail-modal-content {
             background-color: var(--bg-primary);
             border-radius: 0.75rem;


### PR DESCRIPTION
## Summary
- ensure watchlist modal sits above the Netflix-style movie modal

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684bbde56518832384367472ba022dbc