### PR TITLE
Fix bookmark icon size

### DIFF
--- a/index.html
+++ b/index.html
@@ -425,6 +425,9 @@
             width: 36px;
             height: 36px;
         }
+        .action-row .icon-btn i {
+            font-size: 1.1rem;
+        }
 
         .action-row .action-dropdown {
             background-color: var(--card-bg);
@@ -957,6 +960,9 @@
             cursor: pointer;
             transition: border 0.2s;
             box-shadow: 0 1px 3px rgba(60,60,67,0.03);
+        }
+        .dropdown-selected i {
+            font-size: 1.1rem;
         }
         .dropdown-selected:after { display: none; }
         .dropdown-list {


### PR DESCRIPTION
## Summary
- make icons in hero action row 1.1rem for consistent sizing
- match size of watchlist bookmark icon with checkmark by styling `.dropdown-selected i`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684bbf011be0832399fb0461941ab263