### PR TITLE
Update sign-in input styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -1165,6 +1165,17 @@
             border-color: var(--accent-color);
             box-shadow: 0 0 0 2px rgba(var(--science-blue-rgb, 229, 9, 20), 0.3);
         }
+        .auth-form-group input::placeholder {
+            color: var(--text-secondary);
+        }
+        .auth-form-group input:-webkit-autofill {
+            box-shadow: 0 0 0 1000px var(--input-bg-color) inset;
+            -webkit-text-fill-color: var(--text-primary);
+        }
+        .auth-form-group input:-moz-autofill {
+            box-shadow: 0 0 0 1000px var(--input-bg-color) inset;
+            -moz-text-fill-color: var(--text-primary);
+        }
 
         .auth-switch-link {
             text-align: center;


### PR DESCRIPTION
## Summary
- refine sign-in modal input styles so autofill fields follow dark theme
- ensure placeholder text uses secondary color

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684bbf2e26a483239981de0fc1324852