### PR TITLE
Adjust sign-in input background

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
             --header-footer-bg-light-rgb: 253, 253, 253; /* RGB for #fdfdfd */
             --header-footer-bg: rgba(var(--header-footer-bg-light-rgb), 0.9);
             /* Input specific variables for light mode */
-            --input-bg-color: var(--white);
+            --input-bg-color: var(--card-bg);
             --input-border-color: #D1D1D6; /* Apple light gray border */
             --dropdown-bg: #f5f5f7; /* Light mode dropdown background */
             --border-color: #d1d1d6; /* Light mode border color */


### PR DESCRIPTION
## Summary
- tweak light mode input color so sign-in fields are gray instead of bright white

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684bc462b1808323b575c605a65129b9