### PR TITLE
Fix IMDb rating link styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -601,6 +601,8 @@
             background-color: #333;
             padding: 0;
             border-radius: 0.25rem;
+            text-decoration: none;
+            color: inherit;
         }
         .movie-modal-tags a.imdb-link img {
             height: 3rem; /* Increased height for larger IMDb logo */
@@ -611,6 +613,7 @@
             font-size: 0.75rem;
             color: #fff;
             padding-right: 0.25rem;
+            text-decoration: none;
         }
         .movie-modal-description {
             color: var(--text-secondary);
@@ -711,6 +714,8 @@
             background-color: rgba(var(--text-primary-rgb, 255,255,255),0.2);
             padding: 0;
             border-radius: 0.25rem;
+            text-decoration: none;
+            color: inherit;
         }
         .netflix-modal-tags a.imdb-link img {
             height: 1.5rem; /* Match larger IMDb logo size */
@@ -721,6 +726,7 @@
             font-size: 0.75rem;
             color: var(--text-primary);
             padding-right: 0.25rem;
+            text-decoration: none;
         }
         .netflix-modal-body {
             padding: 1rem 1.5rem 1.5rem 1.5rem;


### PR DESCRIPTION
## Summary
- remove link underline styling for IMDb rating elements
- ensure rating text inherits color and stays inside the IMDb badge

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684bc67ddddc8323a6c4ccbff39f83e8