### PR TITLE
Fix mobile watch now button

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,7 @@ Inside the modal you can mark the item as seen using the checkmark button, save
 it to your watchlist with the bookmark icon, or launch the first available
 streaming link by clicking **Watch Now**.
 
+On some mobile browsers, `window.open` may be blocked. The modal now uses a
+helper that falls back to `window.location.href` if opening a new tab fails.
+
 The rest of the project uses plain JavaScript modules, so no React setup is required.

--- a/modules/netflixModal.js
+++ b/modules/netflixModal.js
@@ -1,6 +1,13 @@
 import { renderWatchlistOptionsInModal, createContentCardHtml } from '../ui.js';
 import { getWatchlistsCache, addRemoveItemToFolder, createLibraryFolder } from './libraryManager.js';
 
+function openUrlInNewTab(url) {
+  const newWindow = window.open(url, '_blank');
+  if (!newWindow) {
+    window.location.href = url;
+  }
+}
+
 export function openNetflixModal({ itemDetails = null, imageSrc = '', title = '', tags = [], description = '', imdbUrl = '', rating = null, streamingLinks = [], recommendations = [], series = [], onItemSelect = null } = {}) {
   if (document.getElementById('netflix-modal-overlay')) return;
 
@@ -130,9 +137,9 @@ export function openNetflixModal({ itemDetails = null, imageSrc = '', title = ''
   watchNowBtn.addEventListener('click', () => {
     if (streamingLinks && streamingLinks.length > 0) {
       const url = watchNowSelect.options[selectedLinkIndex]?.value || streamingLinks[0].url;
-      window.open(url, '_blank');
+      openUrlInNewTab(url);
     } else if (imdbUrl) {
-      window.open(imdbUrl, '_blank');
+      openUrlInNewTab(imdbUrl);
     }
   });
 


### PR DESCRIPTION
## Summary
- fallback to opening streaming links in same tab if window.open fails
- document mobile behaviour in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684bc89287508323a8d1ee7e4fd95e43