### PR TITLE
Add track progress feature with new icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -955,6 +955,28 @@
             font-size: 14px;
         }
 
+        /* Track Icon on Card */
+        .track-toggle-icon {
+            position: absolute;
+            bottom: 8px;
+            left: 8px;
+            width: 28px;
+            height: 28px;
+            background-color: var(--card-bg);
+            border: 1px solid var(--accent-color);
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            cursor: pointer;
+            z-index: 5;
+            transition: background-color 0.2s ease-in-out, border-color 0.2s ease-in-out;
+        }
+        .track-toggle-icon i {
+            color: var(--text-secondary);
+            font-size: 14px;
+        }
+
         .content-card p {
             margin-top: 0.75rem; /* mt-3 */
             font-size: 0.875rem; /* text-sm */
@@ -1317,6 +1339,10 @@
             font-size: 14px;
         }
 
+        #track-progress-btn i {
+            font-size: 14px;
+        }
+
         #watch-links-toggle-btn {
             background-color: var(--card-bg);
             color: var(--text-secondary);
@@ -1336,6 +1362,30 @@
             background-color: rgba(var(--white-rgb), 0.2);
         }
         .light-mode #watch-links-toggle-btn:hover {
+            background-color: rgba(var(--black-rgb), 0.2);
+        }
+
+        #track-progress-btn {
+            background-color: var(--card-bg);
+            color: var(--text-secondary);
+            border: 1px solid var(--accent-color);
+            width: 28px;
+            height: 28px;
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            cursor: pointer;
+            padding: 0;
+            transition: background-color 0.2s ease-in-out, color 0.2s ease-in-out;
+        }
+
+        #track-progress-btn:hover {
+            color: var(--white);
+            background-color: rgba(var(--white-rgb), 0.2);
+        }
+
+        .light-mode #track-progress-btn:hover {
             background-color: rgba(var(--black-rgb), 0.2);
         }
 

--- a/ui.js
+++ b/ui.js
@@ -146,6 +146,9 @@ export function createContentCardHtml(item, isLightMode, isItemSeenFn) {
                 <div class="bookmark-toggle-icon" title="Add to Watchlist">
                     <i class="fa-regular fa-bookmark"></i>
                 </div>
+                <div class="track-toggle-icon" title="Track Progress">
+                    <i class="fas fa-pencil-alt"></i>
+                </div>
                 <img src="${posterPath || fallbackImageUrl}" alt="${title}"
                     onerror="if(this.src!==this.dataset.fallback){this.src=this.dataset.fallback;}"
                     data-fallback="${fallbackImageUrl}">
@@ -383,6 +386,7 @@ export function displayItemDetails(detailsObject, itemType, isLightMode) {
     itemDetailModal.style.display = 'flex';
     document.body.style.overflow = 'hidden';
     setupWatchLinksToggle();
+    setupTrackProgressToggle(detailsObject);
 }
 
 /**
@@ -419,6 +423,23 @@ export function setupWatchLinksToggle() {
         toggleBtn.onclick = (e) => {
             e.stopPropagation();
             linksContainer.style.display = linksContainer.style.display === 'none' ? 'block' : 'none';
+        };
+    }
+}
+
+export function setupTrackProgressToggle(showDetails) {
+    const trackBtn = document.getElementById('track-progress-btn');
+    const trackContainer = document.getElementById('track-progress-container');
+    if (trackBtn && trackContainer) {
+        trackBtn.onclick = (e) => {
+            e.stopPropagation();
+            const shouldShow = trackContainer.style.display === 'none' || trackContainer.style.display === '';
+            trackContainer.style.display = shouldShow ? 'block' : 'none';
+            if (shouldShow) {
+                import('./modules/track.js').then(({ renderTrackSectionInModal }) => {
+                    renderTrackSectionInModal(showDetails);
+                });
+            }
         };
     }
 }


### PR DESCRIPTION
## Summary
- add `track-toggle-icon` overlay element
- include styles for tracking icon and progress button
- support toggling tracked episodes in `ui.js`
- open old detail modal with tracking when track icon clicked

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684bcaf71fd88323a38345c25e163b65