### PR TITLE
Fix missing progress bar icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>Watch TV - Home</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet">
 
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css">
 
     <link rel="manifest" href="manifest.json">
 

--- a/ui.js
+++ b/ui.js
@@ -147,7 +147,7 @@ export function createContentCardHtml(item, isLightMode, isItemSeenFn) {
                     <i class="fa-regular fa-bookmark"></i>
                 </div>
                 <div class="track-toggle-icon" title="Track Progress">
-                    <i class="fas fa-pencil-alt"></i>
+                    <i class="fas fa-bars-progress"></i>
                 </div>
                 <img src="${posterPath || fallbackImageUrl}" alt="${title}"
                     onerror="if(this.src!==this.dataset.fallback){this.src=this.dataset.fallback;}"
@@ -317,7 +317,7 @@ export function displayItemDetails(detailsObject, itemType, isLightMode) {
 
     const trackButtonHtml = itemType === 'tv'
         ? `<button id="track-progress-btn" title="Track Progress" style="background-color: var(--card-bg); border: 1px solid var(--text-secondary); color: var(--text-primary); padding: 0.75rem; border-radius: 9999px; cursor: pointer;">
-                <i class="fas fa-pencil-alt"></i>
+                <i class="fas fa-bars-progress"></i>
            </button>`
         : '';
 


### PR DESCRIPTION
## Summary
- upgrade FontAwesome to 6.4.2
- switch track progress button to use `fa-bars-progress`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684bd0f20c308323910985bf42974bd7