### PR TITLE
Add episode selection overlay

### DIFF
--- a/api.js
+++ b/api.js
@@ -105,6 +105,19 @@ export async function fetchRecommendations(id, type) {
 }
 
 /**
+ * Fetch details for a specific season of a TV show, including episode info.
+ * @param {number} tvId - The TMDB TV show ID.
+ * @param {number} seasonNumber - The season number to fetch.
+ * @returns {Promise<Object>} Season details including episodes.
+ */
+export async function fetchSeasonDetails(tvId, seasonNumber) {
+    const url = `${TMDB_BASE_URL}/tv/${tvId}/season/${seasonNumber}?api_key=${API_KEY}`;
+    const response = await fetch(url);
+    if (!response.ok) throw new Error('Failed to fetch season details');
+    return await response.json();
+}
+
+/**
  * Fetch all movies belonging to a collection.
  * @param {number} collectionId - The TMDB collection ID.
  * @returns {Promise<Array>} Array of collection parts (movies).

--- a/index.html
+++ b/index.html
@@ -1950,6 +1950,16 @@
         </div>
     </div>
 
+    <!-- Episode Selection Modal -->
+    <div id="episode-modal" class="item-detail-modal">
+        <div class="item-detail-modal-content" style="max-width: 500px; padding: 1.5rem;">
+            <button class="close-button" aria-label="Close"><i class="fas fa-times"></i></button>
+            <h2 id="episode-modal-title" style="font-size: 1.25rem; margin-bottom: 1rem; color: var(--text-primary);">Select Episode</h2>
+            <select id="episode-season-select" style="margin-bottom:1rem; width:100%; padding:0.5rem; background:var(--input-bg-color); color:var(--text-primary); border:1px solid var(--input-border-color); border-radius:4px;"></select>
+            <div id="episode-list" class="dropdown-list hide-scrollbar" style="position: static; border: none; box-shadow: none; max-height: 300px; overflow-y: auto;"></div>
+        </div>
+    </div>
+
     <!-- Secondary Sidebar HTML (for mobile "More" options) -->
     <div id="secondary-sidebar" class="secondary-sidebar">
         <button class="close-secondary-sidebar" title="Close" aria-label="Close"><i class="fas fa-times"></i></button>

--- a/main.js
+++ b/main.js
@@ -442,8 +442,7 @@ window.onload = async () => {
                         displayItemDetails(details, type, isLightMode);
                         updateSeenButtonStateInModal(id, type, SeenItemsManager.isItemSeen);
                         TrackManager.renderTrackSectionInModal(details);
-                        const c = document.getElementById('track-progress-container');
-                        if (c) c.style.display = 'block';
+                        TrackManager.openEpisodeModal(details);
                     } catch (error) {
                         console.error('Error opening track modal:', error);
                         showCustomAlert('Error', `Could not load item details. Error: ${error.message}`);

--- a/ui.js
+++ b/ui.js
@@ -429,17 +429,13 @@ export function setupWatchLinksToggle() {
 
 export function setupTrackProgressToggle(showDetails) {
     const trackBtn = document.getElementById('track-progress-btn');
-    const trackContainer = document.getElementById('track-progress-container');
-    if (trackBtn && trackContainer) {
+    if (trackBtn) {
         trackBtn.onclick = (e) => {
             e.stopPropagation();
-            const shouldShow = trackContainer.style.display === 'none' || trackContainer.style.display === '';
-            trackContainer.style.display = shouldShow ? 'block' : 'none';
-            if (shouldShow) {
-                import('./modules/track.js').then(({ renderTrackSectionInModal }) => {
-                    renderTrackSectionInModal(showDetails);
-                });
-            }
+            import('./modules/track.js').then(({ openEpisodeModal, renderTrackSectionInModal }) => {
+                renderTrackSectionInModal(showDetails);
+                openEpisodeModal(showDetails);
+            });
         };
     }
 }


### PR DESCRIPTION
## Summary
- add API helper to fetch season details
- enable overlay with seasons and episodes to choose progress
- update progress button behaviour to show new overlay
- insert episode selection modal in the HTML

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684bd25d53b08323b594182f12646fa4