### PR TITLE
Add episode selection overlay for TV series

### DIFF
--- a/api.js
+++ b/api.js
@@ -116,3 +116,16 @@ export async function fetchCollectionItems(collectionId) {
     const data = await response.json();
     return data.parts || [];
 }
+
+/**
+ * Fetch all episodes for a specific season of a TV show.
+ * @param {number} tvId - The TMDB TV show ID.
+ * @param {number} seasonNumber - The season number.
+ * @returns {Promise<Object>} Season data including episodes array.
+ */
+export async function fetchSeasonEpisodes(tvId, seasonNumber) {
+    const url = `${TMDB_BASE_URL}/tv/${tvId}/season/${seasonNumber}?api_key=${API_KEY}`;
+    const response = await fetch(url);
+    if (!response.ok) throw new Error('Failed to fetch season details');
+    return await response.json();
+}

--- a/index.html
+++ b/index.html
@@ -483,6 +483,10 @@
         #links-modal {
             z-index: 1100;
         }
+        /* Ensure episodes overlay sits above the movie modal */
+        #episodes-modal {
+            z-index: 1100;
+        }
 
         .item-detail-modal-content {
             background-color: var(--bg-primary);
@@ -1947,6 +1951,19 @@
             <button class="close-button" aria-label="Close"><i class="fas fa-times"></i></button>
             <h2 style="font-size: 1.25rem; margin-bottom: 1rem; color: var(--text-primary);">Choose Provider</h2>
             <div id="provider-options-list" class="dropdown-list hide-scrollbar" style="position: static; border: none; box-shadow: none; max-height: 300px; overflow-y: auto;"></div>
+        </div>
+    </div>
+
+    <!-- Episodes Modal -->
+    <div id="episodes-modal" class="item-detail-modal">
+        <div class="item-detail-modal-content" style="max-width: 600px; padding: 1.5rem;">
+            <button class="close-button" aria-label="Close"><i class="fas fa-times"></i></button>
+            <h2 id="episodes-modal-title" style="font-size: 1.25rem; margin-bottom: 1rem; color: var(--text-primary);">Episodes</h2>
+            <div id="episodes-season-list" style="max-height:400px; overflow-y:auto;"></div>
+            <div class="filter-dropdown-footer" style="border-radius:0.75rem; display:flex; justify-content: space-between; margin-top:1rem;">
+                <button id="episodes-seen-all" class="filter-action-button">Seen All</button>
+                <button id="episodes-save" class="filter-action-button apply">Save</button>
+            </div>
         </div>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -1955,7 +1955,7 @@
     </div>
 
     <!-- Episodes Modal -->
-    <div id="episodes-modal" class="item-detail-modal">
+    <div id="episodes-modal" class="item-detail-modal" style="display:none;">
         <div class="item-detail-modal-content" style="max-width: 600px; padding: 1.5rem;">
             <button class="close-button" aria-label="Close"><i class="fas fa-times"></i></button>
             <h2 id="episodes-modal-title" style="font-size: 1.25rem; margin-bottom: 1rem; color: var(--text-primary);">Episodes</h2>

--- a/main.js
+++ b/main.js
@@ -13,6 +13,7 @@ import * as SearchManager from './modules/search.js';
 import * as SeenItemsManager from './modules/seenItems.js';
 import * as LibraryManager from './modules/libraryManager.js';
 import * as TrackManager from './modules/track.js';
+import * as EpisodesSeenManager from './modules/episodesSeen.js';
 
 // Import Netflix-style modal helpers
 import { openNetflixModal, openWatchlistModal } from './modules/netflixModal.js';
@@ -196,6 +197,7 @@ window.onload = async () => {
                 console.log("Auth state changed: User signed in - UID:", user.uid);
                 // Initialize seen items and library listeners for the newly signed-in user
                 SeenItemsManager.initializeSeenItemsListener(populateCurrentTabContent);
+                EpisodesSeenManager.initializeEpisodesListener(populateCurrentTabContent);
                 LibraryManager.initializeLibraryListener(
                     (isItemSeenFn, isLightMode, onCardClickCallback) => LibraryManager.renderLibraryFolderCards(isItemSeenFn, isLightMode, onCardClickCallback),
                     (folderId, isItemSeenFn, isLightMode, onCardClickCallback) => LibraryManager.renderMoviesInSelectedFolder(folderId, isItemSeenFn, isLightMode, onCardClickCallback),
@@ -208,6 +210,7 @@ window.onload = async () => {
                 console.log("Auth state changed: User signed out");
                 // Clear any local caches that depend on user being signed in
                 SeenItemsManager.initializeSeenItemsListener(populateCurrentTabContent); // Re-initialize to clear cache
+                EpisodesSeenManager.initializeEpisodesListener(populateCurrentTabContent);
                 LibraryManager.initializeLibraryListener(
                     (isItemSeenFn, isLightMode, onCardClickCallback) => LibraryManager.renderLibraryFolderCards(isItemSeenFn, isLightMode, onCardClickCallback),
                     (folderId, isItemSeenFn, isLightMode, onCardClickCallback) => LibraryManager.renderMoviesInSelectedFolder(folderId, isItemSeenFn, isLightMode, onCardClickCallback),
@@ -223,6 +226,7 @@ window.onload = async () => {
         // Initialize seen items and library managers with their listeners immediately if user is already authenticated (e.g., page refresh)
         // This ensures data is loaded even if the initial auth state is already signed in.
         SeenItemsManager.initializeSeenItemsListener(populateCurrentTabContent);
+        EpisodesSeenManager.initializeEpisodesListener(populateCurrentTabContent);
         LibraryManager.initializeLibraryListener(
             (isItemSeenFn, isLightMode, onCardClickCallback) => LibraryManager.renderLibraryFolderCards(isItemSeenFn, isLightMode, onCardClickCallback),
             (folderId, isItemSeenFn, isLightMode, onCardClickCallback) => LibraryManager.renderMoviesInSelectedFolder(folderId, isItemSeenFn, isLightMode, onCardClickCallback),
@@ -307,6 +311,7 @@ window.onload = async () => {
 
             openNetflixModal({
                 itemDetails: details,
+                itemType: type,
                 imageSrc,
                 title: details.title || details.name || '',
                 tags,
@@ -375,6 +380,7 @@ window.onload = async () => {
             }
             openNetflixModal({
                 itemDetails: details,
+                itemType: type,
                 imageSrc,
                 title: details.title || details.name || '',
                 tags,

--- a/modules/episodesSeen.js
+++ b/modules/episodesSeen.js
@@ -1,0 +1,33 @@
+// modules/episodesSeen.js
+import { getCurrentUser, saveUserData, listenToUserCollection } from '../SignIn/firebase_api.js';
+
+let episodesCache = [];
+let unsubscribeEpisodes = null;
+
+export function initializeEpisodesListener(onUpdateCallback) {
+    if (unsubscribeEpisodes) {
+        unsubscribeEpisodes();
+        unsubscribeEpisodes = null;
+    }
+    const user = getCurrentUser();
+    if (user) {
+        unsubscribeEpisodes = listenToUserCollection('seenEpisodes', (items) => {
+            episodesCache = items;
+            if (onUpdateCallback) onUpdateCallback();
+        });
+    } else {
+        episodesCache = [];
+        if (onUpdateCallback) onUpdateCallback();
+    }
+}
+
+export function getSeenEpisodesForShow(showId) {
+    const record = episodesCache.find(item => String(item.id) === String(showId));
+    return record ? (record.episodes || {}) : {};
+}
+
+export async function markEpisodesSeen(showId, episodesMap) {
+    const user = getCurrentUser();
+    if (!user) return;
+    await saveUserData('seenEpisodes', String(showId), { id: showId, episodes: episodesMap });
+}

--- a/modules/netflixModal.js
+++ b/modules/netflixModal.js
@@ -120,15 +120,17 @@ export function openNetflixModal({ itemDetails = null, itemType = '', imageSrc =
   });
 
   // --- Button functionality ---
-  let isSeen = false;
-
   seenBtn.addEventListener('click', async () => {
-    if (itemType === 'tv' && itemDetails) {
+    if (!itemDetails) return;
+    if (itemType === 'tv') {
       openEpisodesModal(itemDetails);
     } else {
-      isSeen = !isSeen;
-      seenBtn.classList.toggle('active', isSeen);
-      seenBtn.title = isSeen ? 'Marked as Seen' : 'Mark as Seen';
+      const { toggleSeenStatus, isItemSeen } = await import('./seenItems.js');
+      const current = isItemSeen(itemDetails.id, itemType || 'movie');
+      await toggleSeenStatus(itemDetails, itemType || 'movie');
+      const newState = !current;
+      seenBtn.classList.toggle('active', newState);
+      seenBtn.title = newState ? 'Marked as Seen' : 'Mark as Seen';
     }
   });
 


### PR DESCRIPTION
## Summary
- enable marking specific episodes as seen
- support fetching episodes by season
- show new modal overlay for selecting episodes
- track seen episodes in Firestore
- update TV modals to open episode selector

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684bd2f91b348323bf7d47fbacb669d8