### PR TITLE
Fix progress bar icon to open episode selector

### DIFF
--- a/modules/netflixModal.js
+++ b/modules/netflixModal.js
@@ -1,6 +1,6 @@
 import { renderWatchlistOptionsInModal, createContentCardHtml } from '../ui.js';
 import { getWatchlistsCache, addRemoveItemToFolder, createLibraryFolder } from './libraryManager.js';
-import { renderTrackSectionInModal } from './track.js';
+import { renderTrackSectionInModal, openEpisodeModal } from './track.js';
 
 export function openNetflixModal({ itemDetails = null, imageSrc = '', title = '', tags = [], description = '', imdbUrl = '', rating = null, streamingLinks = [], recommendations = [], series = [], onItemSelect = null } = {}) {
   if (document.getElementById('netflix-modal-overlay')) return;
@@ -143,6 +143,7 @@ export function openNetflixModal({ itemDetails = null, imageSrc = '', title = ''
       container.style.display = shouldShow ? 'block' : 'none';
       if (shouldShow && itemDetails) {
         renderTrackSectionInModal(itemDetails);
+        openEpisodeModal(itemDetails);
       }
     });
   }


### PR DESCRIPTION
## Summary
- update Netflix-style modal to open episode selector when the progress icon is clicked

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684bd6d08bb48323b7a648d315b578e5