### PR TITLE
Fix z-index so episode progress modal shows above detail modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -483,6 +483,10 @@
         #links-modal {
             z-index: 1100;
         }
+        /* Ensure episode selection overlay sits above the movie modal */
+        #episode-modal {
+            z-index: 1100;
+        }
 
         .item-detail-modal-content {
             background-color: var(--bg-primary);


### PR DESCRIPTION
## Summary
- ensure the episode progress overlay appears above the movie detail modal

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684bd92618c4832384a3eaad0aad049f