### PR TITLE
Handle seen selection via checkmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,10 @@ openNetflixModal({
 ```
 
 Inside the modal you can mark the item as seen using the checkmark button, save
-it to your watchlist with the bookmark icon, or launch the first available
-streaming link by clicking **Watch Now**.
+it to your watchlist with the bookmark icon, track your progress with the bars
+icon, or launch the first available streaming link by clicking **Watch Now**.
+For TV shows, the checkmark button lets you select individual episodes or mark
+an entire season as seen, while the progress icon simply bookmarks the episode
+you last watched.
 
 The rest of the project uses plain JavaScript modules, so no React setup is required.

--- a/modules/netflixModal.js
+++ b/modules/netflixModal.js
@@ -82,6 +82,15 @@ export function openNetflixModal({ itemDetails = null, imageSrc = '', title = ''
   seenBtn.setAttribute('aria-label', 'Mark as Seen');
   actions.appendChild(seenBtn);
 
+  if (itemDetails) {
+    import('./seenItems.js').then(({ isItemSeen }) => {
+      const type = itemDetails.media_type || (itemDetails.title ? 'movie' : 'tv');
+      const seen = isItemSeen(itemDetails.id, type);
+      seenBtn.classList.toggle('active', seen);
+      seenBtn.title = seen ? 'Mark as Unseen' : 'Mark as Seen';
+    }).catch(() => {});
+  }
+
   const watchlistDropdown = document.createElement('div');
   watchlistDropdown.className = 'apple-dropdown';
   watchlistDropdown.id = 'add-to-folder-dropdown-modal';
@@ -149,12 +158,22 @@ export function openNetflixModal({ itemDetails = null, imageSrc = '', title = ''
   }
 
   // --- Button functionality ---
-  let isSeen = false;
-
-  seenBtn.addEventListener('click', () => {
-    isSeen = !isSeen;
-    seenBtn.classList.toggle('active', isSeen);
-    seenBtn.title = isSeen ? 'Marked as Seen' : 'Mark as Seen';
+  seenBtn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    if (!itemDetails) return;
+    const type = itemDetails.media_type || (itemDetails.title ? 'movie' : 'tv');
+    import('./seenItems.js')
+      .then(async ({ openSeenEpisodesModal, toggleSeenStatus, isItemSeen }) => {
+        if (type === 'tv') {
+          await openSeenEpisodesModal(itemDetails);
+        } else {
+          await toggleSeenStatus(itemDetails, type);
+        }
+        const nowSeen = isItemSeen(itemDetails.id, type);
+        seenBtn.classList.toggle('active', nowSeen);
+        seenBtn.title = nowSeen ? 'Mark as Unseen' : 'Mark as Seen';
+      })
+      .catch(() => {});
   });
 
 


### PR DESCRIPTION
## Summary
- improve docs on progress vs seen buttons
- update Netflix modal checkmark to open the seen episodes modal or toggle movie status

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684be5fad2a4832389e1b06833e6f613