### PR TITLE
Add Explore category filter overlay

### DIFF
--- a/api.js
+++ b/api.js
@@ -136,3 +136,34 @@ export async function fetchCollectionItems(collectionId) {
     const data = await response.json();
     return data.parts || [];
 }
+
+// --- Additional Helpers for Explore Categories ---
+
+/**
+ * Fetch top rated movies or TV shows.
+ * @param {'movie'|'tv'} mediaType
+ * @param {number} page
+ * @returns {Promise<Array>}
+ */
+export async function fetchTopRatedItems(mediaType = 'movie', page = 1) {
+    const url = `${TMDB_BASE_URL}/${mediaType}/top_rated?api_key=${API_KEY}&page=${page}`;
+    const response = await fetch(url);
+    if (!response.ok) throw new Error('Failed to fetch top rated items');
+    const data = await response.json();
+    return (data.results || []).map(item => ({ ...item, media_type: mediaType }));
+}
+
+/**
+ * Fetch classic movies or TV shows released before the year 2000.
+ * @param {'movie'|'tv'} mediaType
+ * @param {number} page
+ * @returns {Promise<Array>}
+ */
+export async function fetchClassicItems(mediaType = 'movie', page = 1) {
+    const url = `${TMDB_BASE_URL}/discover/${mediaType}?api_key=${API_KEY}&sort_by=vote_average.desc&vote_count.gte=500&primary_release_date.lte=2000-12-31&page=${page}`;
+    const response = await fetch(url);
+    if (!response.ok) throw new Error('Failed to fetch classic items');
+    const data = await response.json();
+    return (data.results || []).map(item => ({ ...item, media_type: mediaType }));
+}
+

--- a/index.html
+++ b/index.html
@@ -1753,6 +1753,9 @@
                     <i class="fas fa-filter"></i>
                 </button>
             </div>
+            <button id="explore-category-button" title="Explore Categories" aria-label="Explore Categories">
+                <i class="fas fa-th-large"></i>
+            </button>
             <button data-tab="search-tab" title="Search" aria-label="Search">
                 <i class="fas fa-search"></i>
             </button>
@@ -1931,6 +1934,15 @@
         </div>
     </div>
 
+    <!-- Explore Category Modal -->
+    <div id="explore-category-modal" class="item-detail-modal">
+        <div class="item-detail-modal-content" style="max-width: 300px; padding: 1.5rem;">
+            <button class="close-button" aria-label="Close"><i class="fas fa-times"></i></button>
+            <h2 style="font-size: 1.25rem; margin-bottom: 1rem; color: var(--text-primary);">Explore Categories</h2>
+            <div id="explore-category-options" class="dropdown-list hide-scrollbar" style="position: static; border: none; box-shadow: none;"></div>
+        </div>
+    </div>
+
     <!-- Watchlist Modal -->
     <div id="watchlist-modal" class="item-detail-modal">
         <div class="item-detail-modal-content" style="max-width: 300px; padding: 1.5rem;">
@@ -1973,6 +1985,7 @@
         <div class="secondary-sidebar-content">
             <button id="theme-toggle-mobile"><i class="fas fa-sun"></i> Theme</button>
             <button id="filter-button-mobile"><i class="fas fa-filter"></i> Filter</button>
+            <button id="explore-category-button-mobile"><i class="fas fa-th-large"></i> Explore</button>
             <button id="search-button-mobile"><i class="fas fa-search"></i> Search</button>
             <button id="profile-button-mobile"><i class="fas fa-user-circle"></i> Profile</button>
         </div>


### PR DESCRIPTION
## Summary
- add helper API functions for classic and top-rated categories
- add explore category modal with options
- implement logic in contentManager to load items based on selected explore category
- connect overlay via new header/mobile buttons and event handlers

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684beacbe2ac8323858bcd9fea62296d