### PR TITLE
Add back navigation to movie modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,4 +29,7 @@ For TV shows, the checkmark button lets you select individual episodes or mark
 an entire season as seen, while the progress icon simply bookmarks the episode
 you last watched.
 
+When you open another item from the recommendations inside a modal, a back
+arrow appears so you can return to the previous modal without losing your place.
+
 The rest of the project uses plain JavaScript modules, so no React setup is required.

--- a/index.html
+++ b/index.html
@@ -692,6 +692,20 @@
         .netflix-modal-close:hover {
             color: var(--accent-hover);
         }
+        .netflix-modal-back {
+            position: absolute;
+            top: 0.75rem;
+            left: 0.75rem;
+            background: none;
+            border: none;
+            font-size: 1.75rem;
+            font-weight: bold;
+            color: var(--text-primary);
+            cursor: pointer;
+        }
+        .netflix-modal-back:hover {
+            color: var(--accent-hover);
+        }
         .netflix-modal-image {
             position: relative;
             height: 15rem;


### PR DESCRIPTION
## Summary
- add history stack for Netflix-style modal
- show back arrow when navigating within modal
- allow ESC to go back if history exists
- document back navigation in README

## Testing
- `node -c modules/netflixModal.js`

------
https://chatgpt.com/codex/tasks/task_e_684dc31482dc83238f2c473fbf4f03ea