### PR TITLE
Enable back navigation in movie modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -692,6 +692,20 @@
         .netflix-modal-close:hover {
             color: var(--accent-hover);
         }
+        .netflix-modal-back {
+            position: absolute;
+            top: 0.75rem;
+            left: 0.75rem;
+            background: none;
+            border: none;
+            font-size: 1.75rem;
+            font-weight: bold;
+            color: var(--text-primary);
+            cursor: pointer;
+        }
+        .netflix-modal-back:hover {
+            color: var(--accent-hover);
+        }
         .netflix-modal-image {
             position: relative;
             height: 15rem;

--- a/modules/netflixModal.js
+++ b/modules/netflixModal.js
@@ -2,15 +2,20 @@ import { renderWatchlistOptionsInModal, createContentCardHtml } from '../ui.js';
 import { getWatchlistsCache, addRemoveItemToFolder, createLibraryFolder } from './libraryManager.js';
 import { renderTrackSectionInModal, openEpisodeModal } from './track.js';
 
-export function openNetflixModal({ itemDetails = null, imageSrc = '', title = '', tags = [], description = '', imdbUrl = '', rating = null, streamingLinks = [], recommendations = [], series = [], onItemSelect = null } = {}) {
+export function openNetflixModal({ itemDetails = null, imageSrc = '', title = '', tags = [], description = '', imdbUrl = '', rating = null, streamingLinks = [], recommendations = [], series = [], onItemSelect = null, onBack = null, onClose = null } = {}) {
   if (document.getElementById('netflix-modal-overlay')) return;
 
   const overlay = document.createElement('div');
   overlay.id = 'netflix-modal-overlay';
   overlay.className = 'netflix-modal-overlay';
 
+  const handleClose = () => {
+    closeNetflixModal();
+    if (onClose) onClose();
+  };
+
   const handleKeyDown = event => {
-    if (event.key === 'Escape') closeNetflixModal();
+    if (event.key === 'Escape') handleClose();
   };
   document.addEventListener('keydown', handleKeyDown);
   overlay._handleKeyDown = handleKeyDown;
@@ -21,8 +26,19 @@ export function openNetflixModal({ itemDetails = null, imageSrc = '', title = ''
   const closeBtn = document.createElement('button');
   closeBtn.className = 'netflix-modal-close';
   closeBtn.innerHTML = '<i class="fas fa-times"></i>';
-  closeBtn.addEventListener('click', closeNetflixModal);
+  closeBtn.addEventListener('click', handleClose);
   modal.appendChild(closeBtn);
+
+  if (onBack) {
+    const backBtn = document.createElement('button');
+    backBtn.className = 'netflix-modal-back';
+    backBtn.innerHTML = '<i class="fas fa-arrow-left"></i>';
+    backBtn.addEventListener('click', () => {
+      closeNetflixModal();
+      onBack();
+    });
+    modal.appendChild(backBtn);
+  }
 
   const imageSection = document.createElement('div');
   imageSection.className = 'netflix-modal-image';
@@ -264,7 +280,7 @@ export function openNetflixModal({ itemDetails = null, imageSrc = '', title = ''
 
   overlay.addEventListener('click', event => {
     if (event.target === overlay) {
-      closeNetflixModal();
+      handleClose();
     }
   });
 


### PR DESCRIPTION
## Summary
- add back button styles
- support `onBack` and `onClose` in `openNetflixModal`
- keep modal navigation history in `main.js`
- clear modal history when closing a modal

## Testing
- `npm test` *(fails: Missing script)*
- `npm install` *(fails: integrity checksum error)*

------
https://chatgpt.com/codex/tasks/task_e_684dc71609fc832380ae1596af854a32