### PR TITLE
Add watchlist renaming feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The rest of the project uses plain JavaScript modules, so no React setup is requ
 
 Folders in the **Library** tab can be rearranged by dragging a folder tile onto another.
 The new order is saved to your account so your organization persists across sessions.
+Each folder card also includes a small pencil icon you can click to rename that watchlist.
 
 ## React Movie Library Component
 


### PR DESCRIPTION
## Summary
- allow renaming library folders via a new `renameLibraryFolder` helper
- add pencil icon on folder cards that prompts for a new name
- document renaming in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e1b131ac483238a3cdd2700a3d877