### PR TITLE
[codex] Fix Netflix modal runtime failures

### DIFF
--- a/modules/netflixModal.js
+++ b/modules/netflixModal.js
@@ -1,13 +1,210 @@
-import { renderWatchlistOptionsInModal, createContentCardHtml } from '../ui.js';
-import { getWatchlistsCache, addRemoveItemToFolder, createLibraryFolder } from './modules/libraryManager.js';
-import { renderTrackSectionInModal, openEpisodeModal } from './track.js';
+import { createContentCardHtml, showCustomAlert } from '../ui.js';
+import {
+  addRemoveItemToFolder,
+  createLibraryFolder,
+  getWatchlistFullName,
+  getWatchlistsCache
+} from './libraryManager.js';
+import { isItemSeen, openSeenEpisodesModal, toggleSeenStatus } from './seenItems.js';
+import { openEpisodeModal } from './track.js';
 
-// Store the active keyboard handler so it can be accurately removed later
 let activeKeyHandler = null;
+
+function getItemType(item) {
+  if (!item) return 'movie';
+  return item.media_type || (item.first_air_date || item.name ? 'tv' : 'movie');
+}
+
+function getPosterUrl(item, size = 'w300') {
+  const path = item?.poster_path || item?.backdrop_path;
+  if (!path) return '';
+  if (String(path).startsWith('http')) return path;
+  return 'https://image.tmdb.org/t/p/' + size + path;
+}
+
+function getFoldersContainingItem(itemDetails, itemType) {
+  const itemId = itemDetails?.id;
+  if (!itemId) return [];
+  return getWatchlistsCache()
+    .filter(watchlist => Array.isArray(watchlist.items) && watchlist.items.some(item =>
+      String(item.tmdb_id) === String(itemId) && item.item_type === itemType
+    ))
+    .map(watchlist => watchlist.id);
+}
+
+function renderWatchlistChoices(container, itemDetails, itemType) {
+  const watchlists = getWatchlistsCache();
+  const selectedIds = new Set(getFoldersContainingItem(itemDetails, itemType));
+  container.innerHTML = '';
+
+  if (!watchlists.length) {
+    const empty = document.createElement('div');
+    empty.className = 'dropdown-item';
+    empty.style.cursor = 'default';
+    empty.style.color = 'var(--text-secondary)';
+    empty.textContent = 'No watchlists yet. Use + to create one.';
+    container.appendChild(empty);
+    return selectedIds;
+  }
+
+  watchlists.forEach(watchlist => {
+    const option = document.createElement('button');
+    option.type = 'button';
+    option.className = 'dropdown-item';
+    option.dataset.folderId = watchlist.id;
+    option.style.display = 'flex';
+    option.style.justifyContent = 'space-between';
+    option.style.alignItems = 'center';
+    option.style.width = '100%';
+    option.style.textAlign = 'left';
+
+    const name = document.createElement('span');
+    name.textContent = getWatchlistFullName(watchlist.id) || watchlist.name || 'Untitled Watchlist';
+    option.appendChild(name);
+
+    const checkmark = document.createElement('span');
+    checkmark.className = 'checkmark';
+    checkmark.textContent = selectedIds.has(watchlist.id) ? 'OK' : '';
+    option.appendChild(checkmark);
+
+    if (selectedIds.has(watchlist.id)) {
+      option.classList.add('item-selected');
+    }
+
+    container.appendChild(option);
+  });
+
+  return selectedIds;
+}
+
+function updateWatchlistButton(button, itemDetails, itemType) {
+  const selectedIds = getFoldersContainingItem(itemDetails, itemType);
+  const icon = button.querySelector('i');
+  const isSelected = selectedIds.length > 0;
+  button.classList.toggle('is-selected', isSelected);
+  button.title = isSelected ? 'Edit Watchlists' : 'Add to Watchlist';
+  if (icon) {
+    icon.classList.toggle('fa-solid', isSelected);
+    icon.classList.toggle('fa-regular', !isSelected);
+  }
+}
+
+function updateSeenButton(button, itemDetails, itemType) {
+  if (!button || !itemDetails?.id) return;
+  const seen = isItemSeen(itemDetails.id, itemType);
+  button.classList.toggle('is-seen', seen);
+  button.title = seen ? 'Mark as Unseen' : 'Mark as Seen';
+}
+
+function createWatchlistPanel(itemDetails, itemType, onUpdate) {
+  const panel = document.createElement('div');
+  panel.className = 'netflix-watchlist-panel dropdown-list hide-scrollbar';
+  panel.style.cssText = 'display:none;position:absolute;right:0;top:calc(100% + 0.5rem);min-width:240px;max-height:300px;overflow-y:auto;z-index:1300;background:var(--dropdown-bg);border:1px solid var(--border-color);border-radius:10px;box-shadow:0 12px 30px rgba(0,0,0,0.35);padding:0.35rem;';
+
+  const list = document.createElement('div');
+  panel.appendChild(list);
+
+  const footer = document.createElement('div');
+  footer.className = 'dropdown-footer';
+  footer.style.cssText = 'border-top:1px solid var(--border-color);margin-top:0.35rem;padding-top:0.35rem;text-align:center;';
+
+  const addButton = document.createElement('button');
+  addButton.type = 'button';
+  addButton.textContent = '+';
+  addButton.title = 'Add New Watchlist';
+  addButton.style.cssText = 'background:none;border:none;color:var(--science-blue);font-size:1.5rem;line-height:1;cursor:pointer;width:100%;';
+  footer.appendChild(addButton);
+  panel.appendChild(footer);
+
+  const refresh = () => {
+    renderWatchlistChoices(list, itemDetails, itemType);
+    if (onUpdate) onUpdate();
+  };
+
+  list.addEventListener('click', async event => {
+    const option = event.target.closest('[data-folder-id]');
+    if (!option) return;
+    event.stopPropagation();
+    await addRemoveItemToFolder(option.dataset.folderId, itemDetails, itemType);
+    refresh();
+  });
+
+  addButton.addEventListener('click', async event => {
+    event.stopPropagation();
+    const folderName = prompt('Enter new watchlist name:');
+    if (folderName && folderName.trim()) {
+      await createLibraryFolder(folderName.trim());
+      refresh();
+    }
+  });
+
+  refresh();
+  return panel;
+}
+
+function createElementFromHtml(html) {
+  const wrapper = document.createElement('div');
+  wrapper.innerHTML = html.trim();
+  return wrapper.firstElementChild;
+}
+
+function renderRelatedSection({ title, items, itemDetails, itemType, onItemSelect }) {
+  if (!items || items.length === 0) return null;
+
+  const section = document.createElement('div');
+  section.className = 'netflix-modal-section';
+
+  const heading = document.createElement('h3');
+  heading.textContent = title;
+  section.appendChild(heading);
+
+  const grid = document.createElement('div');
+  grid.className = itemType === 'tv' ? 'episodes-grid' : 'recommendations-grid';
+
+  items.forEach(item => {
+    const card = document.createElement('div');
+    card.className = itemType === 'tv' ? 'episode-card' : 'content-card';
+    card.style.cursor = 'pointer';
+
+    const imageUrl = getPosterUrl(item);
+    const image = document.createElement('div');
+    image.className = itemType === 'tv' ? 'episode-image' : 'image-container';
+    if (imageUrl) image.style.backgroundImage = 'url("' + imageUrl + '")';
+
+    const info = document.createElement('div');
+    info.className = itemType === 'tv' ? 'episode-info' : '';
+
+    const itemTitle = document.createElement('div');
+    itemTitle.className = itemType === 'tv' ? 'episode-title' : '';
+    itemTitle.textContent = item.title || item.name || 'Untitled';
+    info.appendChild(itemTitle);
+
+    const metadata = document.createElement('div');
+    metadata.className = 'episode-metadata';
+    metadata.textContent = itemType === 'tv' && item.season_number ? 'Season ' + item.season_number : '';
+    if (metadata.textContent) info.appendChild(metadata);
+
+    card.appendChild(image);
+    card.appendChild(info);
+    card.addEventListener('click', () => {
+      if (itemType === 'tv') {
+        openEpisodeModal(itemDetails);
+        return;
+      }
+      const selectedType = getItemType(item);
+      if (onItemSelect && item.id) onItemSelect(item.id, selectedType);
+    });
+    grid.appendChild(card);
+  });
+
+  section.appendChild(grid);
+  return section;
+}
 
 export function openNetflixModal({ itemDetails = null, imageSrc = '', title = '', tags = [], description = '', imdbUrl = '', rating = null, streamingLinks = [], recommendations = [], series = [], onItemSelect = null, onBack = null, onClose = null } = {}) {
   if (document.getElementById('netflix-modal-overlay')) return;
 
+  const itemType = getItemType(itemDetails);
   const overlay = document.createElement('div');
   overlay.id = 'netflix-modal-overlay';
   overlay.className = 'netflix-modal-overlay';
@@ -17,23 +214,20 @@ export function openNetflixModal({ itemDetails = null, imageSrc = '', title = ''
     if (onClose) onClose();
   };
 
-  // FIX: Store the listener in a top-level variable
   activeKeyHandler = event => {
     if (event.key === 'Escape') handleClose();
   };
   document.addEventListener('keydown', activeKeyHandler);
 
-  // FIX: Only close if clicking the dark overlay background, not the modal itself
-  overlay.addEventListener('click', (e) => {
-    if (e.target === overlay) {
-      handleClose();
-    }
+  overlay.addEventListener('click', event => {
+    if (event.target === overlay) handleClose();
   });
 
   const modal = document.createElement('div');
   modal.className = 'netflix-modal';
 
   const closeBtn = document.createElement('button');
+  closeBtn.type = 'button';
   closeBtn.className = 'netflix-modal-close';
   closeBtn.innerHTML = '<i class="fas fa-times"></i>';
   closeBtn.addEventListener('click', handleClose);
@@ -41,6 +235,7 @@ export function openNetflixModal({ itemDetails = null, imageSrc = '', title = ''
 
   if (onBack) {
     const backBtn = document.createElement('button');
+    backBtn.type = 'button';
     backBtn.className = 'netflix-modal-back';
     backBtn.innerHTML = '<i class="fas fa-arrow-left"></i>';
     backBtn.addEventListener('click', () => {
@@ -52,7 +247,7 @@ export function openNetflixModal({ itemDetails = null, imageSrc = '', title = ''
 
   const imageSection = document.createElement('div');
   imageSection.className = 'netflix-modal-image';
-  if (imageSrc) imageSection.style.backgroundImage = `url('${imageSrc}')`;
+  if (imageSrc) imageSection.style.backgroundImage = 'url("' + imageSrc + '")';
 
   const infoOverlay = document.createElement('div');
   infoOverlay.className = 'netflix-modal-image-overlay';
@@ -64,15 +259,16 @@ export function openNetflixModal({ itemDetails = null, imageSrc = '', title = ''
   const tagsDiv = document.createElement('div');
   tagsDiv.className = 'netflix-modal-tags';
   let imdbInserted = false;
-  let imdbLink;
+  let imdbLink = null;
   if (imdbUrl) {
     imdbLink = document.createElement('a');
     imdbLink.href = imdbUrl;
     imdbLink.target = '_blank';
+    imdbLink.rel = 'noopener noreferrer';
     imdbLink.className = 'imdb-link';
-    const ratingHtml = rating !== null ? `<span class="imdb-rating">${rating}</span>` : '';
-    imdbLink.innerHTML = `<img src="IMDb.png" alt="IMDb">${ratingHtml}`;
+    imdbLink.innerHTML = '<img src="IMDb.png" alt="IMDb">' + (rating !== null ? '<span class="imdb-rating">' + rating + '</span>' : '');
   }
+
   tags.forEach(tag => {
     const span = document.createElement('span');
     span.textContent = tag;
@@ -82,10 +278,8 @@ export function openNetflixModal({ itemDetails = null, imageSrc = '', title = ''
       imdbInserted = true;
     }
   });
+  if (imdbLink && !imdbInserted) tagsDiv.appendChild(imdbLink);
 
-  if (imdbLink && !imdbInserted) {
-    tagsDiv.appendChild(imdbLink);
-  }
   infoOverlay.appendChild(tagsDiv);
   imageSection.appendChild(infoOverlay);
   modal.appendChild(imageSection);
@@ -93,124 +287,125 @@ export function openNetflixModal({ itemDetails = null, imageSrc = '', title = ''
   const body = document.createElement('div');
   body.className = 'netflix-modal-body';
 
-  const p = document.createElement('p');
-  p.className = 'netflix-modal-description';
-  p.textContent = description;
-  body.appendChild(p);
+  const overview = document.createElement('p');
+  overview.className = 'netflix-modal-description';
+  overview.textContent = description;
+  body.appendChild(overview);
 
   const middleRow = document.createElement('div');
   middleRow.className = 'netflix-modal-middle-row';
 
   const actionsDiv = document.createElement('div');
   actionsDiv.className = 'netflix-modal-actions';
+  actionsDiv.style.position = 'relative';
 
   const watchNowBtn = document.createElement('button');
+  watchNowBtn.type = 'button';
   watchNowBtn.className = 'watch-now-btn';
   watchNowBtn.innerHTML = '<i class="fas fa-play"></i> Watch Now';
   watchNowBtn.addEventListener('click', () => {
     if (streamingLinks && streamingLinks.length > 0) {
-      const firstLink = streamingLinks[0].url;
-      const iframeContainer = document.getElementById('iframe-container');
-      const iframe = document.getElementById('video-iframe');
-      if (iframeContainer && iframe) {
-        iframe.src = firstLink;
-        iframeContainer.style.display = 'block';
-        closeNetflixModal();
-      }
+      window.open(streamingLinks[0].url, '_blank', 'noopener,noreferrer');
+    } else {
+      showCustomAlert('Info', 'No streaming links are available for this item.');
     }
   });
   actionsDiv.appendChild(watchNowBtn);
 
-  // FIX: Added the missing "Seen" button mentioned in the README
   const seenBtn = document.createElement('button');
+  seenBtn.type = 'button';
   seenBtn.className = 'seen-btn';
   seenBtn.innerHTML = '<i class="fas fa-check"></i>';
-  seenBtn.title = 'Mark as Seen';
-  seenBtn.addEventListener('click', () => {
-    // Add your logic to mark item as seen here
-    console.log('Marked as seen');
+  seenBtn.addEventListener('click', async event => {
+    event.stopPropagation();
+    if (!itemDetails?.id) {
+      showCustomAlert('Info', 'Item details are still loading. Please try again.');
+      return;
+    }
+    if (itemType === 'tv') {
+      await openSeenEpisodesModal(itemDetails);
+    } else {
+      await toggleSeenStatus(itemDetails, itemType);
+    }
+    updateSeenButton(seenBtn, itemDetails, itemType);
   });
+  updateSeenButton(seenBtn, itemDetails, itemType);
   actionsDiv.appendChild(seenBtn);
 
-  // FIX: Added the missing "Track" button utilizing your unused import
-  const trackBtn = document.createElement('button');
-  trackBtn.className = 'track-btn';
-  trackBtn.innerHTML = '<i class="fas fa-bars"></i>';
-  trackBtn.title = 'Track Progress';
-  trackBtn.addEventListener('click', (e) => {
-    e.stopPropagation();
-    const rect = trackBtn.getBoundingClientRect();
-    renderTrackSectionInModal(itemDetails, {
-      top: rect.bottom + window.scrollY,
-      left: rect.left + window.scrollX
+  if (itemType === 'tv') {
+    const trackBtn = document.createElement('button');
+    trackBtn.type = 'button';
+    trackBtn.className = 'track-btn';
+    trackBtn.innerHTML = '<i class="fas fa-bars-progress"></i>';
+    trackBtn.title = 'Track Progress';
+    trackBtn.addEventListener('click', event => {
+      event.stopPropagation();
+      if (itemDetails) openEpisodeModal(itemDetails);
     });
-  });
-  actionsDiv.appendChild(trackBtn);
+    actionsDiv.appendChild(trackBtn);
+  }
+
+  const watchlistWrapper = document.createElement('div');
+  watchlistWrapper.style.position = 'relative';
+  watchlistWrapper.style.display = 'inline-flex';
 
   const watchlistBtn = document.createElement('button');
+  watchlistBtn.type = 'button';
   watchlistBtn.className = 'watchlist-btn';
-  watchlistBtn.innerHTML = '<i class="fas fa-bookmark"></i>'; // Changed to bookmark to match README
-  watchlistBtn.title = 'Add to Watchlist';
-  watchlistBtn.addEventListener('click', (e) => {
-    e.stopPropagation();
-    const rect = watchlistBtn.getBoundingClientRect();
-    renderWatchlistOptionsInModal(itemDetails, {
-      top: rect.bottom + window.scrollY,
-      left: rect.left + window.scrollX
-    });
+  watchlistBtn.innerHTML = '<i class="fa-regular fa-bookmark"></i>';
+  updateWatchlistButton(watchlistBtn, itemDetails, itemType);
+
+  const watchlistPanel = createWatchlistPanel(itemDetails, itemType, () => updateWatchlistButton(watchlistBtn, itemDetails, itemType));
+  watchlistBtn.addEventListener('click', event => {
+    event.stopPropagation();
+    watchlistPanel.style.display = watchlistPanel.style.display === 'block' ? 'none' : 'block';
   });
-  actionsDiv.appendChild(watchlistBtn);
+  watchlistWrapper.appendChild(watchlistBtn);
+  watchlistWrapper.appendChild(watchlistPanel);
+  actionsDiv.appendChild(watchlistWrapper);
+
+  modal.addEventListener('click', event => {
+    if (!event.target.closest('.netflix-watchlist-panel') && !event.target.closest('.watchlist-btn')) {
+      watchlistPanel.style.display = 'none';
+    }
+  });
 
   middleRow.appendChild(actionsDiv);
   body.appendChild(middleRow);
 
-  if (series && series.length > 0) {
-    const episodesSection = document.createElement('div');
-    episodesSection.className = 'netflix-modal-section';
-    const sectionTitle = document.createElement('h3');
-    sectionTitle.textContent = 'Episodes';
-    episodesSection.appendChild(sectionTitle);
-
-    const episodesGrid = document.createElement('div');
-    episodesGrid.className = 'episodes-grid';
-    series.forEach(episode => {
-      const episodeCard = document.createElement('div');
-      episodeCard.className = 'episode-card';
-      episodeCard.innerHTML = `
-        <div class="episode-image" style="background-image: url('${episode.image}')">
-          <div class="episode-play-overlay"><i class="fas fa-play"></i></div>
-        </div>
-        <div class="episode-info">
-          <div class="episode-title">${episode.title}</div>
-          <div class="episode-metadata">S${episode.season} E${episode.number}</div>
-        </div>
-      `;
-      episodeCard.addEventListener('click', () => {
-        openEpisodeModal(episode, series);
-      });
-      episodesGrid.appendChild(episodeCard);
-    });
-    episodesSection.appendChild(episodesGrid);
-    body.appendChild(episodesSection);
-  }
+  const relatedSection = renderRelatedSection({
+    title: itemType === 'tv' ? 'Seasons' : 'In This Collection',
+    items: series,
+    itemDetails,
+    itemType,
+    onItemSelect
+  });
+  if (relatedSection) body.appendChild(relatedSection);
 
   if (recommendations && recommendations.length > 0) {
     const recSection = document.createElement('div');
     recSection.className = 'netflix-modal-section';
+
     const recTitle = document.createElement('h3');
     recTitle.textContent = 'More Like This';
     recSection.appendChild(recTitle);
 
     const recGrid = document.createElement('div');
     recGrid.className = 'recommendations-grid';
+    const isLightMode = document.body.classList.contains('light-mode');
+
     recommendations.forEach(rec => {
-      const recCard = createContentCardHtml(rec);
-      recCard.addEventListener('click', () => {
+      const recType = getItemType(rec);
+      const card = createElementFromHtml(createContentCardHtml({ ...rec, media_type: recType }, isLightMode, isItemSeen));
+      if (!card) return;
+      card.addEventListener('click', event => {
+        if (event.target.closest('.seen-toggle-icon') || event.target.closest('.bookmark-toggle-icon')) return;
         closeNetflixModal();
-        if (onItemSelect) onItemSelect(rec);
+        if (onItemSelect) onItemSelect(rec.id, recType);
       });
-      recGrid.appendChild(recCard);
+      recGrid.appendChild(card);
     });
+
     recSection.appendChild(recGrid);
     body.appendChild(recSection);
   }
@@ -218,6 +413,7 @@ export function openNetflixModal({ itemDetails = null, imageSrc = '', title = ''
   modal.appendChild(body);
   overlay.appendChild(modal);
   document.body.appendChild(overlay);
+  document.body.style.overflow = 'hidden';
 
   setTimeout(() => overlay.classList.add('active'), 10);
 }
@@ -228,11 +424,66 @@ export function closeNetflixModal() {
     overlay.classList.remove('active');
     setTimeout(() => {
       overlay.remove();
-      // FIX: accurately remove the correct listener using the variable reference
+      document.body.style.overflow = '';
       if (activeKeyHandler) {
         document.removeEventListener('keydown', activeKeyHandler);
-        activeKeyHandler = null; 
+        activeKeyHandler = null;
       }
     }, 400);
   }
+}
+
+export function openWatchlistModal(itemDetails = null) {
+  const modal = document.getElementById('watchlist-modal');
+  const list = document.getElementById('watchlist-options-list');
+  const addButton = document.getElementById('watchlist-add-btn');
+  const doneButton = document.getElementById('watchlist-modal-done');
+
+  if (!itemDetails || !modal || !list) {
+    showCustomAlert('Info', 'Select a movie or show before adding it to a watchlist.');
+    return;
+  }
+
+  const itemType = getItemType(itemDetails);
+  const refresh = () => renderWatchlistChoices(list, itemDetails, itemType);
+  refresh();
+
+  list.onclick = async event => {
+    const option = event.target.closest('[data-folder-id]');
+    if (!option) return;
+    await addRemoveItemToFolder(option.dataset.folderId, itemDetails, itemType);
+    refresh();
+  };
+
+  if (addButton) {
+    const newAddButton = addButton.cloneNode(true);
+    addButton.parentNode.replaceChild(newAddButton, addButton);
+    newAddButton.addEventListener('click', async () => {
+      const folderName = prompt('Enter new watchlist name:');
+      if (folderName && folderName.trim()) {
+        await createLibraryFolder(folderName.trim());
+        refresh();
+      }
+    });
+  }
+
+  const close = () => {
+    modal.style.display = 'none';
+    document.body.style.overflow = '';
+  };
+
+  if (doneButton) {
+    const newDoneButton = doneButton.cloneNode(true);
+    doneButton.parentNode.replaceChild(newDoneButton, doneButton);
+    newDoneButton.addEventListener('click', close);
+  }
+
+  const closeButton = modal.querySelector('.close-button');
+  if (closeButton) closeButton.onclick = close;
+  modal.onclick = event => {
+    if (event.target === modal) close();
+  };
+
+  modal.style.display = 'flex';
+  document.body.style.overflow = 'hidden';
 }


### PR DESCRIPTION
## Summary

Fixes the Netflix-style modal so it no longer breaks the app module graph or crashes when users interact with modal content.

## What changed

- Corrected the modal's library manager import path.
- Added the missing `openWatchlistModal` export that `main.js` imports.
- Reworked modal actions for watch now, seen status, TV progress, and watchlist selection.
- Fixed recommendation cards so they are created as DOM elements and call `onItemSelect(id, type)` correctly.
- Replaced broken season/collection rendering paths that used undefined fields.

## Root cause

`main.js` imported `openWatchlistModal`, but `modules/netflixModal.js` did not export it. The modal also imported `./modules/libraryManager.js` from inside the `modules` directory, which resolves to a missing nested path. Either issue can stop the browser from loading the module graph.

## Validation

- Parsed the replacement as an ES module with the local JavaScript parser.
- Compared the branch against `main`; the PR only modifies `modules/netflixModal.js`.

I could not run the full app locally in this environment because Git is not installed here and the app depends on live browser/Firebase/TMDB behavior.