### PR TITLE
[codex] Update watch sources and same-tab playback

### DIFF
--- a/config.js
+++ b/config.js
@@ -5,8 +5,8 @@ export const TMDB_IMG_BASE_URL = "https://image.tmdb.org/t/p/w500";
 export const TMDB_BACKDROP_BASE_URL = "https://image.tmdb.org/t/p/w1280";
 
 export const VIDSRC_PROVIDERS = [
-    { name: "Vidsrc.xyz", movieUrl: "https://vidsrc.xyz/embed/movie/", tvUrl: "https://vidsrc.xyz/embed/tv/" },
     { name: "Vidsrc.pm",  movieUrl: "https://vidsrc.pm/embed/movie/",  tvUrl: "https://vidsrc.pm/embed/tv/" },
     { name: "Vidsrc.in",  movieUrl: "https://vidsrc.in/embed/movie/",  tvUrl: "https://vidsrc.in/embed/tv/" },
-    { name: "Vidsrc.net", movieUrl: "https://vidsrc.net/embed/movie/", tvUrl: "https://vidsrc.net/embed/tv/" },
+    { name: "Vidsrcme.ru", movieUrl: "https://vidsrcme.ru/embed/movie/", tvUrl: "https://vidsrcme.ru/embed/tv/" },
+    { name: "Vidsrcme.su", movieUrl: "https://vidsrcme.su/embed/movie/", tvUrl: "https://vidsrcme.su/embed/tv/" },
 ];

--- a/modules/netflixModal.js
+++ b/modules/netflixModal.js
@@ -173,14 +173,18 @@ function ensureNetflixModalStyles() {
 .netflix-watch-now-wrap {
   position: relative;
   display: inline-flex;
+  z-index: 20;
 }
 .netflix-watch-menu {
   position: absolute;
   left: 0;
   top: calc(100% + 0.7rem);
-  z-index: 4;
+  z-index: 30;
   box-sizing: border-box;
   width: min(19rem, calc(100vw - 2rem));
+  max-height: min(19rem, calc(100vh - 7rem));
+  overflow-y: auto;
+  overscroll-behavior: contain;
   display: none;
   border: 1px solid rgba(var(--white-rgb), 0.16);
   border-radius: 8px;
@@ -191,6 +195,13 @@ function ensureNetflixModalStyles() {
 .netflix-watch-menu.is-open {
   display: grid;
   gap: 0.55rem;
+}
+.netflix-watch-menu::-webkit-scrollbar {
+  width: 8px;
+}
+.netflix-watch-menu::-webkit-scrollbar-thumb {
+  border-radius: 999px;
+  background: rgba(var(--white-rgb), 0.24);
 }
 .netflix-watch-menu-title {
   margin: 0 0 0.15rem;
@@ -260,56 +271,6 @@ function ensureNetflixModalStyles() {
 }
 .netflix-watch-link i {
   color: var(--text-secondary);
-}
-.netflix-watch-player-overlay {
-  position: fixed;
-  inset: 0;
-  z-index: 1500;
-  display: flex;
-  flex-direction: column;
-  background: #050505;
-}
-.netflix-watch-player-header {
-  min-height: 3.5rem;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  padding: 0.65rem 1rem;
-  background: #111;
-  border-bottom: 1px solid rgba(var(--white-rgb), 0.12);
-}
-.netflix-watch-player-title {
-  min-width: 0;
-  margin: 0;
-  color: var(--white);
-  font-size: 0.95rem;
-  font-weight: 800;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-.netflix-watch-player-close {
-  width: 2.4rem;
-  height: 2.4rem;
-  border: 0;
-  border-radius: 50%;
-  background: rgba(var(--white-rgb), 0.12);
-  color: var(--white);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-}
-.netflix-watch-player-close:hover {
-  background: rgba(var(--white-rgb), 0.2);
-}
-.netflix-watch-player-frame {
-  flex: 1 1 auto;
-  width: 100%;
-  min-height: 0;
-  border: 0;
-  background: #000;
 }
 .netflix-watchlist-panel .dropdown-item {
   background: transparent;
@@ -487,6 +448,7 @@ function ensureNetflixModalStyles() {
   }
   .netflix-watch-menu {
     width: 100%;
+    max-height: min(16rem, calc(100vh - 6rem));
   }
   .netflix-modal-section-header {
     padding: 0 1rem;
@@ -757,58 +719,14 @@ function createWatchOptionLink(link) {
   const button = document.createElement('button');
   button.type = 'button';
   button.className = 'netflix-watch-link';
-  button.innerHTML = '<span>' + link.name + '</span><i class="fas fa-play"></i>';
+  button.title = 'Open ' + link.name;
+  button.innerHTML = '<span>' + link.name + '</span><i class="fas fa-arrow-right"></i>';
   button.addEventListener('click', event => {
     event.preventDefault();
     event.stopPropagation();
-    openEmbeddedWatchPlayer(link);
+    window.location.assign(link.url);
   });
   return button;
-}
-
-function closeEmbeddedWatchPlayer() {
-  const player = document.getElementById('netflix-watch-player-overlay');
-  if (player) player.remove();
-}
-
-function openEmbeddedWatchPlayer(link) {
-  if (!link?.url) return;
-  closeEmbeddedWatchPlayer();
-  document.querySelectorAll('.netflix-watch-menu.is-open').forEach(menu => {
-    menu.classList.remove('is-open');
-  });
-
-  const overlay = document.createElement('div');
-  overlay.id = 'netflix-watch-player-overlay';
-  overlay.className = 'netflix-watch-player-overlay';
-
-  const header = document.createElement('div');
-  header.className = 'netflix-watch-player-header';
-
-  const title = document.createElement('p');
-  title.className = 'netflix-watch-player-title';
-  title.textContent = link.name || 'Now Playing';
-  header.appendChild(title);
-
-  const closeButton = document.createElement('button');
-  closeButton.type = 'button';
-  closeButton.className = 'netflix-watch-player-close';
-  closeButton.title = 'Close player';
-  closeButton.innerHTML = '<i class="fas fa-times"></i>';
-  closeButton.addEventListener('click', closeEmbeddedWatchPlayer);
-  header.appendChild(closeButton);
-
-  const frame = document.createElement('iframe');
-  frame.className = 'netflix-watch-player-frame';
-  frame.src = link.url;
-  frame.title = link.name || 'Watch source';
-  frame.allow = 'autoplay; encrypted-media; fullscreen; picture-in-picture';
-  frame.allowFullscreen = true;
-  frame.referrerPolicy = 'no-referrer-when-downgrade';
-
-  overlay.appendChild(header);
-  overlay.appendChild(frame);
-  document.body.appendChild(overlay);
 }
 
 function navigateToItem(item, onItemSelect) {
@@ -969,12 +887,7 @@ export function openNetflixModal({ itemDetails = null, imageSrc = '', title = ''
   };
 
   activeKeyHandler = event => {
-    if (event.key !== 'Escape') return;
-    if (document.getElementById('netflix-watch-player-overlay')) {
-      closeEmbeddedWatchPlayer();
-      return;
-    }
-    handleClose();
+    if (event.key === 'Escape') handleClose();
   };
   document.addEventListener('keydown', activeKeyHandler);
 


### PR DESCRIPTION
## What changed

- Adds `vidsrcme.ru` and `vidsrcme.su` to the shared watch provider list.
- Removes `vidsrc.xyz` and `vidsrc.net` from the provider list.
- Makes the `Watch Now` source menu scrollable and raises it above nearby modal layers so covered choices can still be reached.
- Removes the iframe player overlay and opens the chosen source in the same browser tab instead. This avoids the provider-side `refused to connect` iframe block without opening a second tab.

## Validation

- Ran JavaScript syntax checks on `modules/netflixModal.js` and `config.js`.
- Confirmed the updated provider config contains `vidsrcme.ru` and `vidsrcme.su` and no longer contains `vidsrc.xyz` or `vidsrc.net`.
- Confirmed the modal no longer contains the iframe player code or `window.open()` for watch sources.