### PR TITLE
[codex] Keep watch source links in separate tabs

### DIFF
--- a/modules/netflixModal.js
+++ b/modules/netflixModal.js
@@ -716,17 +716,14 @@ function normalizeStreamingLinks(streamingLinks = []) {
 }
 
 function createWatchOptionLink(link) {
-  const button = document.createElement('button');
-  button.type = 'button';
-  button.className = 'netflix-watch-link';
-  button.title = 'Open ' + link.name;
-  button.innerHTML = '<span>' + link.name + '</span><i class="fas fa-arrow-right"></i>';
-  button.addEventListener('click', event => {
-    event.preventDefault();
-    event.stopPropagation();
-    window.location.assign(link.url);
-  });
-  return button;
+  const anchor = document.createElement('a');
+  anchor.className = 'netflix-watch-link';
+  anchor.href = link.url;
+  anchor.target = '_blank';
+  anchor.rel = 'noopener noreferrer';
+  anchor.title = 'Open ' + link.name + ' in a new tab';
+  anchor.innerHTML = '<span>' + link.name + '</span><i class="fas fa-arrow-up-right-from-square"></i>';
+  return anchor;
 }
 
 function navigateToItem(item, onItemSelect) {


### PR DESCRIPTION
## What changed

- Restores the `Watch Now` source choices to normal links that open in a separate tab.
- Keeps the movie/details modal open in the app so you can return to the exact place you were browsing.
- Keeps the merged scrollable source menu, new provider list, and removed iframe player behavior from the previous PR.

## Why

The embedded player approach can be blocked by provider sites, and same-tab playback makes it easy to lose your place in the app. Opening the chosen source separately keeps playback working while preserving the browsing screen.

## Validation

- Ran JavaScript syntax checks on `modules/netflixModal.js` and `config.js` locally.
- Confirmed the follow-up branch is 1 commit ahead of `main` and only changes `modules/netflixModal.js`.
- Confirmed the selected source rows now use `_blank` links with `noopener noreferrer`.